### PR TITLE
[Feat] 로그인 API 연결 및 전역 상태 관리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,24 +12,28 @@ import SearchResultPage from "@/pages/searchResult/SearchResultPage";
 import TeamBoardPage from "@/pages/teamBoard/TeamBoardPage";
 import UserSpacePage from "@/pages/userSpace/UserSpacePage";
 import Layout from "@/components/layout/Layout";
+import RequireAuth from "@/components/router/RequireAuth";
 
 const App = () => {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
-        <Route path="/" element={<Layout />}>
-          <Route index element={<HomePage />} />
-          <Route path="/assigned" element={<AssignedPage />} />
-          <Route path="/team/:id" element={<TeamBoardPage />} />
-          <Route path="/my-questions" element={<MyQuestionsPage />} />
-          <Route path="/inquiry/form" element={<InquiryFormPage />} />
-          <Route path="/scrap" element={<ScrapPage />} />
-          <Route path="/space/:username" element={<UserSpacePage />} />
-          {/* 👆 :username은 api에 따라 변경 가능 */}
-          <Route path="/inquiries/:id" element={<InquiryDetailPage />} />
-          <Route path="/result" element={<SearchResultPage />} />
+
+        <Route element={<RequireAuth />}>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<HomePage />} />
+            <Route path="/assigned" element={<AssignedPage />} />
+            <Route path="/team/:id" element={<TeamBoardPage />} />
+            <Route path="/my-questions" element={<MyQuestionsPage />} />
+            <Route path="/inquiry/form" element={<InquiryFormPage />} />
+            <Route path="/scrap" element={<ScrapPage />} />
+            <Route path="/space/:username" element={<UserSpacePage />} />
+            <Route path="/inquiries/:id" element={<InquiryDetailPage />} />
+            <Route path="/result" element={<SearchResultPage />} />
+          </Route>
         </Route>
+
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/apis/auth/authApi.ts
+++ b/src/apis/auth/authApi.ts
@@ -1,0 +1,18 @@
+import { ApiResponse } from "@/types/apiResponse.type";
+import {
+  PostLoginRequest,
+  PostLoginResponse,
+} from "@/types/login/loginApi.type";
+
+import instance from "@/apis/instance";
+
+export const postLogin = async (
+  data: PostLoginRequest
+): ApiResponse<PostLoginResponse> => {
+  const response = await instance.post("/api/users/login", data);
+  return response.data;
+};
+
+// TODO: postLogout
+
+// TODO: postRefreshToken

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,0 +1,37 @@
+import axios from "axios";
+
+import { getAuthStore } from "@/store/getAuthStore";
+import { useAuthStore } from "@/store/useAuthStore";
+
+const instance = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  withCredentials: true,
+});
+
+// 요청 인터셉터
+instance.interceptors.request.use(config => {
+  const { accessToken } = getAuthStore();
+
+  if (accessToken) {
+    config.headers["Authorization"] = `Bearer ${accessToken}`;
+  }
+
+  return config;
+});
+
+// 응답 인터셉터: 401 (Unauthorized) 에러 시 처리
+instance.interceptors.response.use(
+  res => res,
+  err => {
+    if (err.response?.status === 401) {
+      // 로그아웃 처리
+      useAuthStore.getState().setLogout();
+
+      window.location.href = "/login";
+    }
+
+    return Promise.reject(err);
+  }
+);
+
+export default instance;

--- a/src/apis/search/search.ts
+++ b/src/apis/search/search.ts
@@ -1,17 +1,9 @@
-import axios from "axios";
-
-// API 기본 설정
-const api = axios.create({
-  baseURL: process.env.REACT_APP_API_URL || "/api",
-  headers: {
-    "Content-Type": "application/json",
-  },
-});
+import instance from "@/apis/instance";
 
 // 최근 검색어 조회
 export const getRecentSearchKeywords = async () => {
   try {
-    const response = await api.get("/search/inquiries/recent");
+    const response = await instance.get("/search/inquiries/recent");
     return response.data;
   } catch (error) {
     console.error("최근 검색어 조회 실패:", error);
@@ -22,7 +14,7 @@ export const getRecentSearchKeywords = async () => {
 // 최근 검색어 삭제
 export const deleteRecentSearchKeyword = async (keyword: string) => {
   try {
-    const response = await api.delete(`/search/inquiries/recent`, {
+    const response = await instance.delete(`/search/inquiries/recent`, {
       data: { keyword },
     });
     return response.data;
@@ -35,7 +27,7 @@ export const deleteRecentSearchKeyword = async (keyword: string) => {
 // 추천 검색어 조회
 export const getRecommendSearchKeywords = async (query: string) => {
   try {
-    const response = await api.get(
+    const response = await instance.get(
       `/search/inquiries/suggestions?query=${encodeURIComponent(query)}`
     );
     return response.data;
@@ -48,7 +40,7 @@ export const getRecommendSearchKeywords = async (query: string) => {
 // 검색 결과 조회
 export const getSearchResults = async (query: string, page: number = 1) => {
   try {
-    const response = await api.get(
+    const response = await instance.get(
       `/search/inquiries/results?query=${query}&page=${page}`
     );
     return response.data;

--- a/src/components/inbox/InboxItem.tsx
+++ b/src/components/inbox/InboxItem.tsx
@@ -94,7 +94,10 @@ const InboxItem = ({ inquiry, isArchived }: Props) => {
           {/* hover 상태일 때만 표시 */}
           {isArchived ? (
             <div className="hidden transition group-hover:flex w-[32px] ml-auto h-[32px] items-center bg-white border border-gray-20 rounded-[8px] p-1">
-              <div className="group/reset relative w-6 h-6 bg-white transition duration-100 hover:bg-gray-10 active:bg-gray-20 flex justify-center items-center rounded-[5px]">
+              <div
+                onClick={e => e.stopPropagation()}
+                className="group/reset relative w-6 h-6 bg-white transition duration-100 hover:bg-gray-10 active:bg-gray-20 flex justify-center items-center rounded-[5px]"
+              >
                 <Reset className="w-4 h-auto transition duration-100 text-gray-50 hover:text-gray-70" />
                 <div className="absolute bottom-8 h-[22px] px-2 bg-main-dark rounded-[8px] flex justify-center items-center opacity-0 group-hover/reset:opacity-100 z-10">
                   <span className="text-detail3 text-white whitespace-nowrap">

--- a/src/components/login/IDInputField.tsx
+++ b/src/components/login/IDInputField.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 
 import clsx from "clsx";
 
@@ -16,9 +16,15 @@ interface Props {
   value: string; // 입력값
   setValue: (v: string) => void; // 입력값 변경 함수
   errorTypeID?: "none" | "invalid" | "notfound"; // 오류 상태
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
-const IDInputField = ({ value, setValue, errorTypeID = "none" }: Props) => {
+const IDInputField = ({
+  value,
+  setValue,
+  errorTypeID = "none",
+  onKeyDown,
+}: Props) => {
   const [isFocused, setIsFocused] = useState(false); // 포커스(클릭, 입력중) 여부
   const [isHovered, setIsHovered] = useState(false); // 호버 여부
 
@@ -84,6 +90,7 @@ const IDInputField = ({ value, setValue, errorTypeID = "none" }: Props) => {
             onChange={e => handleChange(e.target.value)}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
+            onKeyDown={onKeyDown}
             placeholder={!showLabel ? "Employee ID" : ""}
             autoComplete="username"
             className={`

--- a/src/components/login/PasswordInputField.tsx
+++ b/src/components/login/PasswordInputField.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import clsx from "clsx";
 
@@ -16,12 +16,14 @@ interface Props {
   value: string; // 입력값
   setValue: (v: string) => void; // 입력값 변경 함수
   errorTypePw?: "none" | "invalid"; // 오류 상태
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
 const PasswordInputField = ({
   value,
   setValue,
   errorTypePw = "none",
+  onKeyDown,
 }: Props) => {
   const [isFocused, setIsFocused] = useState(false); // 포커스 상태
   const [isHovered, setIsHovered] = useState(false); // 호버 상태
@@ -122,6 +124,7 @@ const PasswordInputField = ({
             onChange={e => handleChange(e.target.value)}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
+            onKeyDown={onKeyDown}
             placeholder={!showLabel ? "Password" : ""}
             autoComplete="current-password"
             className={`

--- a/src/components/router/RequireAuth.tsx
+++ b/src/components/router/RequireAuth.tsx
@@ -1,0 +1,11 @@
+import { Navigate, Outlet } from "react-router-dom";
+
+import { useAuthStore } from "@/store/useAuthStore";
+
+const RequireAuth = () => {
+  const isLogin = useAuthStore(state => state.isLogin);
+
+  return isLogin ? <Outlet /> : <Navigate to="/login" replace />;
+};
+
+export default RequireAuth;

--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -1,0 +1,29 @@
+import axios from "axios";
+
+import { ErrorResponse } from "@/types/apiResponse.type";
+import { PostLoginRequest } from "@/types/login/loginApi.type";
+
+import { useAuthApi } from "./useAuthApi";
+
+import { useAuthStore } from "@/store/useAuthStore";
+
+export const useAuth = () => {
+  const { isLogin } = useAuthStore();
+  const { postLoginMutation } = useAuthApi();
+
+  const login = async ({ employeeId, password }: PostLoginRequest) => {
+    try {
+      await postLoginMutation.mutateAsync({ employeeId, password });
+    } catch (error) {
+      if (axios.isAxiosError<ErrorResponse>(error)) {
+        throw error.response?.data.code;
+      }
+    }
+  };
+
+  // TODO: logout
+
+  // TODO: refresh
+
+  return { isLogin, login };
+};

--- a/src/hooks/auth/useAuthApi.ts
+++ b/src/hooks/auth/useAuthApi.ts
@@ -1,0 +1,23 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { postLogin } from "@/apis/auth/authApi";
+import { useAuthStore } from "@/store/useAuthStore";
+
+export const useAuthApi = () => {
+  const login = useAuthStore(state => state.setLogin);
+  // const logout = useAuthStore(state => state.setLogout);
+
+  const postLoginMutation = useMutation({
+    mutationFn: postLogin,
+    onSuccess: res => {
+      const { accessToken } = res.result;
+      login({ accessToken: accessToken });
+    },
+  });
+
+  // TODO: postLogoutMutation
+
+  // TODO: postRefreshTokenMutation
+
+  return { postLoginMutation };
+};

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -5,7 +5,7 @@ import {
   getRecentSearchKeywords,
   getRecommendSearchKeywords,
   getSearchResults,
-} from "@/api/search";
+} from "@/apis/search/search";
 
 // 최근 검색어 조회 훅
 export const useRecentSearchKeywords = () => {

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -56,6 +56,12 @@ const LoginPage = () => {
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && isLoginEnabled) {
+      handleLogin();
+    }
+  };
+
   return (
     <div className="w-full h-screen bg-gray-10 flex items-center justify-center">
       <div className="w-[360px] h-[475px] flex flex-col items-center">
@@ -68,11 +74,13 @@ const LoginPage = () => {
             value={employeeId}
             setValue={setEmployeeId}
             errorTypeID={errorTypeID}
+            onKeyDown={handleKeyDown}
           />
           <PasswordInputField
             value={password}
             setValue={setPassword}
             errorTypePw={errorTypePw}
+            onKeyDown={handleKeyDown}
           />
         </form>
 

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from "react";
 
+import { useNavigate } from "react-router-dom";
+
 import Logo from "@/assets/svgs/login/logo.svg";
 import IDInputField from "@/components/login/IDInputField";
 import PasswordInputField from "@/components/login/PasswordInputField";
+import { useAuth } from "@/hooks/auth/useAuth";
 
 const LoginPage = () => {
   const [employeeId, setEmployeeId] = useState("");
@@ -11,43 +14,45 @@ const LoginPage = () => {
     "invalid" | "notfound" | "none"
   >("none");
   const [errorTypePw, seterrorTypePw] = useState<"none" | "invalid">("none");
-
-  const validAccounts = [
-    { id: "test@test.com", pw: "1234" },
-    { id: "admin@sh.com", pw: "admin123" },
-  ];
-
-  // 사번(이메일) 형식 유효성 검사
-  useEffect(() => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-    if (employeeId.length === 0) {
-      setErrorTypeID("none");
-    } else if (!emailRegex.test(employeeId)) {
-      setErrorTypeID("invalid");
-    } else {
-      const matched = validAccounts.find(acc => acc.id === employeeId);
-      setErrorTypeID(matched ? "none" : "notfound");
-    }
-  }, [employeeId]);
+  const { login } = useAuth();
 
   // 로그인 버튼 활성화 조건
   const isLoginEnabled = employeeId.length > 0 && password.length > 0;
 
-  // 로그인 처리 함수
-  const handleLogin = async () => {
-    const matched = validAccounts.find(
-      acc => acc.id === employeeId && acc.pw === password
-    );
+  const navigate = useNavigate();
 
-    if (!matched) {
-      console.error("로그인 실패: 잘못된 ID 또는 PW");
+  // 사번 형식 (영어, 숫자만) 유효성 검사
+  useEffect(() => {
+    const idRegex = /^[a-zA-Z0-9]+$/;
+
+    if (employeeId.length === 0) {
       setErrorTypeID("none");
-      seterrorTypePw("invalid");
+    } else if (!idRegex.test(employeeId)) {
+      setErrorTypeID("invalid");
     } else {
-      console.log("로그인 성공");
+      setErrorTypeID("none");
+    }
+  }, [employeeId]);
+
+  const handleLogin = async () => {
+    try {
+      await login({ employeeId, password });
       setErrorTypeID("none");
       seterrorTypePw("none");
+      navigate("/");
+    } catch (code) {
+      if (code === "USER400") {
+        // 비밀번호 오류
+        setErrorTypeID("none");
+        seterrorTypePw("invalid");
+      } else if (code === "USER404") {
+        // 사번 오류
+        setErrorTypeID("notfound");
+        seterrorTypePw("none");
+      } else {
+        setErrorTypeID("invalid");
+        seterrorTypePw("invalid");
+      }
     }
   };
 

--- a/src/pages/notFound/NotFoundPage.tsx
+++ b/src/pages/notFound/NotFoundPage.tsx
@@ -4,9 +4,11 @@ import Home from "@/assets/svgs/layout/home.svg";
 import NotFound from "@/assets/svgs/notFound/404.svg";
 import Button from "@/components/common/Button";
 
+import { useAuthStore } from "@/store/useAuthStore";
+
 const NotFoundPage = () => {
   const navigate = useNavigate();
-  const isLogin = true; // TODO: 로그인 연결 이후 변경
+  const isLogin = useAuthStore(state => state.isLogin);
 
   const handleClick = () => {
     if (isLogin) {

--- a/src/store/getAuthStore.ts
+++ b/src/store/getAuthStore.ts
@@ -1,0 +1,3 @@
+import { useAuthStore } from "@/store/useAuthStore";
+
+export const getAuthStore = () => useAuthStore.getState();

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+type AuthState = {
+  accessToken: string | null;
+  isLogin: boolean;
+  setLogin: (tokens: { accessToken: string }) => void;
+  setLogout: () => void;
+};
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    set => ({
+      accessToken: null,
+      isLogin: false,
+      setLogin: ({ accessToken }) => set({ accessToken, isLogin: true }),
+      setLogout: () => set({ accessToken: null, isLogin: false }),
+    }),
+    {
+      name: "auth-storage",
+      storage: createJSONStorage(() => localStorage),
+      partialize: state => ({
+        accessToken: state.accessToken,
+        isLogin: state.isLogin,
+      }),
+      onRehydrateStorage: state => {
+        if (!state.accessToken) {
+          state.isLogin = false;
+        }
+      },
+    }
+  )
+);

--- a/src/types/apiResponse.type.ts
+++ b/src/types/apiResponse.type.ts
@@ -5,5 +5,11 @@ export type GlobalResponse<T> = {
   result: T;
 };
 
+// 응답 Response Type
 export type ApiResponse<T> = Promise<GlobalResponse<T>>;
+
+// 응답 데이터가 없는 경우 (ex. delete)
+export type NoResponse = Record<string, never>;
+
+// 에러 응답
 export type ErrorResponse = GlobalResponse<Record<string, never>>;

--- a/src/types/apiResponse.type.ts
+++ b/src/types/apiResponse.type.ts
@@ -1,0 +1,9 @@
+export type GlobalResponse<T> = {
+  is_success: boolean;
+  code: string;
+  message: string;
+  result: T;
+};
+
+export type ApiResponse<T> = Promise<GlobalResponse<T>>;
+export type ErrorResponse = GlobalResponse<Record<string, never>>;

--- a/src/types/login/loginApi.type.ts
+++ b/src/types/login/loginApi.type.ts
@@ -1,0 +1,9 @@
+export interface PostLoginRequest {
+  employeeId: string;
+  password: string;
+}
+
+export interface PostLoginResponse {
+  accessToken: string;
+  refreshToken: string;
+}


### PR DESCRIPTION
### 💡 To Reviewers

- login, logout, refresh token 관련 API 가 추후 나올 수 있어 폴더나 파일명을 login 이 아닌 auth 로 하였습니다.

---

### 🔥 작업 내용
 @Wannys26 @chaeyoungwon @chan000518 @dudulic @Kuuuuu00 **_(해당 PR 모두 읽어주세요)_**

- 기본 axios 통신 instance 생성하였습니다. (apis/instance.ts) API 연결하실 때 **instance.** 꼭 붙여 사용해주세요.
  - 401 (unauthorized) 에러 발생 시 자동 로그아웃 및 /login 페이지로 라우팅 처리하였습니다.
  - 자동으로 헤더에 token 들어갑니다. 
  - 지금은 아니지만 추후 refresh token 에 쿠키가 사용될 수 있어 withCredentials: true 넣어놓았습니다. (백과 상의 완료)
  
- 로그인 API 연결하였습니다.
  - 로그인 성공 시 accessToken을 Zustand(useAuthStore)에 저장합니다.

- 로그인 유효성 검사 로직 변경하였습니다. (백과 상의 완료하였습니다) @Wannys26 (pages/login/LoginPage.tsx)
  - **기존** 이메일 형식이 아닐 때 invalid -> **현재** 영어 + 숫자 형식이 아니라면 invalid
  - 백에서 에러 발생 시 제공해주는 응답 코드로 사번 오류와 비밀번호 오류를 분기처리 하였습니다.
  - 로그인이 성공하면 '/' HomePage로 갑니다.

- 로그인 상태가 아닐 경우 /login 으로 가도록 하였습니다. (components/router/RequireAuth.tsx)

- 로그인 상태가 아닐 경우 404 페이지에서 `홈으로` 누르면 /login 가도록 하였습니다. (로그인 상태라면 '/' 홈으로 갑니다.)

- refresh token 말고 access token만 받아와 persist 사용해 local storage에 저장(accessToken, isLogin)하도록 하였습니다. (백과 상의 완료)

- 로그인 여부는 isLogin으로 전역 관리합니다. 아래와 같이 사용하시면 됩니다.

```
  const isLogin = useAuthStore(state => state.isLogin); 
```

- API 관련 파일들입니다. 이런식으로 파일을 분리해 사용하면 좋을 것 같습니다. 코드 참고해주시면 좋을 것 같습니다.
  - apis/auth/authApi.ts: 로그인 API 함수 정의
  - hooks/auth/useAuthApi.ts: React Query mutation 정의
  - hooks/auth/useAuth.ts: 로그인 로직 및 상태관리
  - pages/login/LoginPage.tsx: 로그인 UI 단에서 API 호출

- API 관련 파일들 명명 규칙은 앞으로 통일하는 게 좋을 것 같습니다. 이렇게 어떠신가요?
```
- apis/도메인/@@@Api.ts : API 함수 정의
- hooks/도메인/use@@@Api.ts : React Query 정의
- hooks/도메인/use@@@.ts : 로직 및 상태관리
```
- types/apiResponse.type.ts 에 GlobalResponse를 정의하였습니다. (ApiResponse, ErrorResponse, NoResponse) src/apis/authApi.ts 참고하셔서 ApiResponse<메서드@@@Response> 로 타입 설정해 API 연결해주시면 됩니다.

- 타입 명명 규칙은 이렇게 어떠신가요? 
```
types/도메인/@@@Api.type.ts 안에 (예시: types/login/loginApi.type.ts 참고)
- 메서드@@@Response  : 응답 타입 (예시: PostLoginResponse)
- 메서드@@@Request : 요청 타입 (예시: PostLoginResquest)
```

---

### 📸 작업 결과 (선택)

> 로그인 유효성 검사 및 사번 에러 처리 로직

https://github.com/user-attachments/assets/7ae15df4-8b57-4250-b48f-421fe82a3fb2

> 사번은 맞고, 비밀번호 에러 처리 로직

https://github.com/user-attachments/assets/dd856283-faca-4f54-81fe-c0ae904ff4d8

> 로그인 안 한 상태에서 막히게 처리 (404 페이지에서도 홈으로 버튼 누르면 로그인 페이지로 감 - 기디와 상의 완료)

https://github.com/user-attachments/assets/35690e9a-1990-4df7-84dd-5c582803e7ca

> 로그인 성공

https://github.com/user-attachments/assets/fc57c690-c4ca-4a4f-9f84-d4b69ec748ad


---

### 🔗 관련 이슈 (선택)

- #36 
