### PR TITLE
[FEAT] 문의글 상세 페이지 - 문의글, 답변 API 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,10 @@ const App = () => {
             <Route path="/inquiry/form" element={<InquiryFormPage />} />
             <Route path="/scrap" element={<ScrapPage />} />
             <Route path="/space/:username" element={<UserSpacePage />} />
-            <Route path="/inquiries/:id" element={<InquiryDetailPage />} />
+            <Route
+              path="/teams/:team_id/inquiries/:inquiry_id"
+              element={<InquiryDetailPage />}
+            />
             <Route path="/result" element={<SearchResultPage />} />
           </Route>
         </Route>

--- a/src/apis/inquiry/answer/answerApi.ts
+++ b/src/apis/inquiry/answer/answerApi.ts
@@ -13,10 +13,8 @@ import {
 
 import axiosInstance from "@/apis/instance";
 
-/**
- * POST /api/inquiries/{inquiry_id}/answers
- * @description 답변 등록
- */
+//POST /api/inquiries/{inquiry_id}/answers
+//답변 등록
 export const postAnswer = async (
   inquiry_id: number,
   data: PostAnswerRequest
@@ -28,10 +26,8 @@ export const postAnswer = async (
   return response.data;
 };
 
-/**
- * PUT /api/answers/{answer_id}
- * @description 답변 수정
- */
+//PUT /api/answers/{answer_id}
+//@description 답변 수정
 export const putAnswer = async (
   answer_id: number,
   data: PutAnswerRequest
@@ -43,10 +39,8 @@ export const putAnswer = async (
   return response.data;
 };
 
-/**
- * DELETE /api/answers/{answer_id}
- * @description 답변 삭제
- */
+// DELETE /api/answers/{answer_id}
+// @description 답변 삭제
 export const deleteAnswer = async (
   answer_id: number
 ): ApiResponse<DeleteAnswerResponse> => {
@@ -56,10 +50,8 @@ export const deleteAnswer = async (
   return response.data;
 };
 
-/**
- * POST /api/inquiries/{inquiry_id}/confirm
- * @description 문의 확인 처리 (답변 등록 대신)
- */
+// POST /api/inquiries/{inquiry_id}/confirm
+// @description 문의 확인 처리 (답변 등록 대신)
 export const postInquiryConfirm = async (
   inquiry_id: number
 ): ApiResponse<NoResponse> => {

--- a/src/apis/inquiry/answer/answerApi.ts
+++ b/src/apis/inquiry/answer/answerApi.ts
@@ -1,0 +1,70 @@
+import {
+  ApiResponse,
+  GlobalResponse,
+  NoResponse,
+} from "@/types/apiResponse.type";
+import {
+  DeleteAnswerResponse,
+  PostAnswerRequest,
+  PostAnswerResponse,
+  PutAnswerRequest,
+  PutAnswerResponse,
+} from "@/types/inquiry/answerApi.type";
+
+import axiosInstance from "@/apis/instance";
+
+/**
+ * POST /api/inquiries/{inquiry_id}/answers
+ * @description 답변 등록
+ */
+export const postAnswer = async (
+  inquiry_id: number,
+  data: PostAnswerRequest
+): ApiResponse<PostAnswerResponse> => {
+  const response = await axiosInstance.post<GlobalResponse<PostAnswerResponse>>(
+    `/api/inquiries/${inquiry_id}/answers`,
+    data
+  );
+  return response.data;
+};
+
+/**
+ * PUT /api/answers/{answer_id}
+ * @description 답변 수정
+ */
+export const putAnswer = async (
+  answer_id: number,
+  data: PutAnswerRequest
+): ApiResponse<PutAnswerResponse> => {
+  const response = await axiosInstance.put<GlobalResponse<PutAnswerResponse>>(
+    `/api/answers/${answer_id}`,
+    data
+  );
+  return response.data;
+};
+
+/**
+ * DELETE /api/answers/{answer_id}
+ * @description 답변 삭제
+ */
+export const deleteAnswer = async (
+  answer_id: number
+): ApiResponse<DeleteAnswerResponse> => {
+  const response = await axiosInstance.delete<
+    GlobalResponse<DeleteAnswerResponse>
+  >(`/api/answers/${answer_id}`);
+  return response.data;
+};
+
+/**
+ * POST /api/inquiries/{inquiry_id}/confirm
+ * @description 문의 확인 처리 (답변 등록 대신)
+ */
+export const postInquiryConfirm = async (
+  inquiry_id: number
+): ApiResponse<NoResponse> => {
+  const response = await axiosInstance.post<GlobalResponse<NoResponse>>(
+    `/api/inquiries/${inquiry_id}/confirm`
+  );
+  return response.data;
+};

--- a/src/apis/inquiry/detail/inquiryDetailApi.ts
+++ b/src/apis/inquiry/detail/inquiryDetailApi.ts
@@ -3,13 +3,8 @@ import { GetInquiryDetailResponse } from "@/types/inquiry/inquiryDetailApi.type"
 
 import axiosInstance from "@/apis/instance";
 
-/**
- * GET /api/teams/{team_id}/inquiries/{inquiry_id}
- * @description 문의글 상세 조회
- * @param {number} team_id
- * @param {number} inquiry_id
- * @returns {ApiResponse<GetInquiryDetailResponse>}
- */
+// GET /api/teams/{team_id}/inquiries/{inquiry_id}
+// 문의글 상세 조회
 export const getInquiryDetail = async (
   team_id: number,
   inquiry_id: number

--- a/src/apis/inquiry/detail/inquiryDetailApi.ts
+++ b/src/apis/inquiry/detail/inquiryDetailApi.ts
@@ -1,0 +1,21 @@
+import { ApiResponse, GlobalResponse } from "@/types/apiResponse.type";
+import { GetInquiryDetailResponse } from "@/types/inquiry/inquiryDetailApi.type";
+
+import axiosInstance from "@/apis/instance";
+
+/**
+ * GET /api/teams/{team_id}/inquiries/{inquiry_id}
+ * @description 문의글 상세 조회
+ * @param {number} team_id
+ * @param {number} inquiry_id
+ * @returns {ApiResponse<GetInquiryDetailResponse>}
+ */
+export const getInquiryDetail = async (
+  team_id: number,
+  inquiry_id: number
+): ApiResponse<GetInquiryDetailResponse> => {
+  const response = await axiosInstance.get<
+    GlobalResponse<GetInquiryDetailResponse>
+  >(`/api/teams/${team_id}/inquiries/${inquiry_id}`);
+  return response.data;
+};

--- a/src/apis/inquiry/detail/inquiryManagementApi.ts
+++ b/src/apis/inquiry/detail/inquiryManagementApi.ts
@@ -14,7 +14,7 @@ import {
 import axiosInstance from "@/apis/instance";
 
 // PUT /api/teams/{team_id}/inquiries/{inquiry_id}/change-assignee
-// 문의 담당자 수정
+// 문의 담당자 변경
 export const putInquiryAssignee = async (
   team_id: number,
   inquiry_id: number,
@@ -41,11 +41,12 @@ export const postInquiryNotify = async (
 // DELETE /api/inquiries/{inquiry_id}
 // 문의글 삭제
 export const deleteInquiry = async (
+  team_id: number,
   inquiry_id: number
 ): ApiResponse<DeleteInquiryResponse> => {
   const response = await axiosInstance.delete<
     GlobalResponse<DeleteInquiryResponse>
-  >(`/api/inquiries/${inquiry_id}`);
+  >(`/api/teams/${team_id}/inquiries/${inquiry_id}`);
   return response.data;
 };
 

--- a/src/apis/inquiry/detail/inquiryManagementApi.ts
+++ b/src/apis/inquiry/detail/inquiryManagementApi.ts
@@ -1,0 +1,37 @@
+import {
+  ApiResponse,
+  GlobalResponse,
+  NoResponse,
+} from "@/types/apiResponse.type";
+import { PutInquiryAssigneeRequest } from "@/types/inquiry/inquiryManagementApi.type";
+
+import axiosInstance from "@/apis/instance";
+
+/**
+ * PUT /api/teams/{team_id}/inquiries/{inquiry_id}/change-assignee
+ * @description 문의 담당자 수정
+ */
+export const putInquiryAssignee = async (
+  team_id: number,
+  inquiry_id: number,
+  data: PutInquiryAssigneeRequest
+): ApiResponse<NoResponse> => {
+  const response = await axiosInstance.put<GlobalResponse<NoResponse>>(
+    `/api/teams/${team_id}/inquiries/${inquiry_id}/change-assignee`,
+    data
+  );
+  return response.data;
+};
+
+/**
+ * POST /inquiries/{inquiry_id}/notify
+ * @description 알림 메일 수동 발송
+ */
+export const postInquiryNotify = async (
+  inquiry_id: number
+): ApiResponse<string> => {
+  const response = await axiosInstance.post<GlobalResponse<string>>(
+    `/inquiries/${inquiry_id}/notify`
+  );
+  return response.data;
+};

--- a/src/apis/inquiry/detail/inquiryManagementApi.ts
+++ b/src/apis/inquiry/detail/inquiryManagementApi.ts
@@ -3,14 +3,18 @@ import {
   GlobalResponse,
   NoResponse,
 } from "@/types/apiResponse.type";
-import { PutInquiryAssigneeRequest } from "@/types/inquiry/inquiryManagementApi.type";
+import {
+  DeleteInquiryResponse,
+  GetLastSentMailTimeResponse,
+  PutInquiryAssigneeRequest,
+  PutInquiryRequest,
+  PutInquiryResponse,
+} from "@/types/inquiry/inquiryManagementApi.type";
 
 import axiosInstance from "@/apis/instance";
 
-/**
- * PUT /api/teams/{team_id}/inquiries/{inquiry_id}/change-assignee
- * @description 문의 담당자 수정
- */
+// PUT /api/teams/{team_id}/inquiries/{inquiry_id}/change-assignee
+// 문의 담당자 수정
 export const putInquiryAssignee = async (
   team_id: number,
   inquiry_id: number,
@@ -23,15 +27,48 @@ export const putInquiryAssignee = async (
   return response.data;
 };
 
-/**
- * POST /inquiries/{inquiry_id}/notify
- * @description 알림 메일 수동 발송
- */
+// POST /inquiries/{inquiry_id}/mails
+// 알림 메일 수동 발송
 export const postInquiryNotify = async (
   inquiry_id: number
 ): ApiResponse<string> => {
   const response = await axiosInstance.post<GlobalResponse<string>>(
-    `/inquiries/${inquiry_id}/notify`
+    `/api/inquiries/${inquiry_id}/mails`
+  );
+  return response.data;
+};
+
+// DELETE /api/inquiries/{inquiry_id}
+// 문의글 삭제
+export const deleteInquiry = async (
+  inquiry_id: number
+): ApiResponse<DeleteInquiryResponse> => {
+  const response = await axiosInstance.delete<
+    GlobalResponse<DeleteInquiryResponse>
+  >(`/api/inquiries/${inquiry_id}`);
+  return response.data;
+};
+
+// GET /api/inquiries/{inquiry_id}/mails/last-sent-time
+// 마지막 메일 전송 시간을 조회합니다.
+export const getLastSentMailTime = async (
+  inquiry_id: number
+): ApiResponse<GetLastSentMailTimeResponse> => {
+  const response = await axiosInstance.get<
+    GlobalResponse<GetLastSentMailTimeResponse>
+  >(`/api/inquiries/${inquiry_id}/mails/last-sent-time`);
+  return response.data;
+};
+
+// PUT /api/inquiries/{inquiry_id}
+// 문의글 수정
+export const putInquiry = async (
+  inquiry_id: number,
+  data: PutInquiryRequest
+): ApiResponse<PutInquiryResponse> => {
+  const response = await axiosInstance.put<GlobalResponse<PutInquiryResponse>>(
+    `/api/inquiries/${inquiry_id}`,
+    data
   );
   return response.data;
 };

--- a/src/apis/profile/profileApi.ts
+++ b/src/apis/profile/profileApi.ts
@@ -1,0 +1,13 @@
+import { ApiResponse, GlobalResponse } from "@/types/apiResponse.type";
+import { GetMyProfileResponse } from "@/types/profile/profileApi.type";
+
+import axiosInstance from "@/apis/instance";
+
+// GET /api/profile/preview
+// 내 프로필 정보 조회
+export const getMyProfile = async (): ApiResponse<GetMyProfileResponse> => {
+  const response = await axiosInstance.get<
+    GlobalResponse<GetMyProfileResponse>
+  >("/api/profile/preview");
+  return response.data;
+};

--- a/src/apis/scrap/scrapApi.ts
+++ b/src/apis/scrap/scrapApi.ts
@@ -1,0 +1,33 @@
+import { ApiResponse, GlobalResponse } from "@/types/apiResponse.type";
+import {
+  DeleteScrapResponse,
+  PostScrapResponse,
+} from "@/types/scrap/scrapApi.type";
+
+import axiosInstance from "@/apis/instance";
+
+/**
+ * POST /api/scrap/{inquiry_id}
+ * @description 스크랩 추가
+ */
+export const postScrap = async (
+  inquiry_id: number
+): ApiResponse<PostScrapResponse> => {
+  const response = await axiosInstance.post<GlobalResponse<PostScrapResponse>>(
+    `/api/scrap/${inquiry_id}`
+  );
+  return response.data;
+};
+
+/**
+ * DELETE /api/scrap/{inquiry_id}
+ * @description 스크랩 취소
+ */
+export const deleteScrap = async (
+  inquiry_id: number
+): ApiResponse<DeleteScrapResponse> => {
+  const response = await axiosInstance.delete<
+    GlobalResponse<DeleteScrapResponse>
+  >(`/api/scrap/${inquiry_id}`);
+  return response.data;
+};

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -47,7 +47,9 @@ const Modal = ({ isOpen, onClose, title, description, buttons }: Props) => {
           <h2 className="text-heading2-b text-gray-80 break-words">{title}</h2>
           {description && (
             <div className="mt-4 h-12 flex items-center max-w-[400px]">
-              <p className="text-body2 text-gray-60 mx-auto">{description}</p>
+              <p className="text-body2 text-gray-60 mx-auto whitespace-pre-line">
+                {description}
+              </p>
             </div>
           )}
         </div>

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -5,7 +5,7 @@ import ReactDOM from "react-dom";
 import { getButtonClass } from "@/utils/modalUtils";
 import { ModalButton } from "@/types/modal";
 
-interface Props {
+export interface Props {
   isOpen: boolean;
   onClose: () => void;
   title: string;

--- a/src/components/inquiry/detail/AssigneeActions.tsx
+++ b/src/components/inquiry/detail/AssigneeActions.tsx
@@ -2,34 +2,39 @@ import Check from "@/assets/svgs/inquiry/detail/check.svg";
 import Pencil from "@/assets/svgs/inquiry/detail/pencil.svg";
 import Users from "@/assets/svgs/inquiry/detail/users.svg";
 import Button from "@/components/common/Button";
+import type { AssigneeActionsProps } from "@/types/inquiryTypes";
 
-interface AssigneeActionsProps {
-  showAssigneeFeatures: boolean;
-}
-
-const AssigneeActions = ({ showAssigneeFeatures }: AssigneeActionsProps) => {
+const AssigneeActions = ({
+  showAssigneeFeatures,
+  onStartAnswer,
+  onConfirm,
+  isCurrentUserConfirmed,
+  showEditor,
+  hasMyComment,
+}: AssigneeActionsProps) => {
   if (!showAssigneeFeatures) return null;
+
+  const shouldShowAnswerButton = !showEditor && !hasMyComment;
 
   return (
     <div className="flex justify-between items-center w-full">
-      {/* 담당자 수정 버튼 */}
       <Button buttonType="default" className="text-gray-80">
         <Users className="text-gray-80" />
         담당자 수정
       </Button>
-
-      <div className="flex items-center gap-[16px] ">
-        {/* 답변 작성 버튼 */}
-        <Button buttonType="blue">
-          <Pencil />
-          답변 작성
-        </Button>
-
-        {/* 확인 버튼*/}
-        <Button buttonType="green">
-          <Check />
-          확인
-        </Button>
+      <div className="flex items-center gap-[16px]">
+        {shouldShowAnswerButton && (
+          <Button buttonType="blue" onClick={() => onStartAnswer()}>
+            <Pencil />
+            답변 작성
+          </Button>
+        )}
+        {!isCurrentUserConfirmed && (
+          <Button buttonType="green" onClick={onConfirm}>
+            <Check />
+            확인
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/components/inquiry/detail/AssigneeSection.tsx
+++ b/src/components/inquiry/detail/AssigneeSection.tsx
@@ -4,22 +4,16 @@ import ProfileIcon from "@/assets/svgs/inquiry/detail/profile.svg";
 import UserCheck from "@/assets/svgs/inquiry/detail/user-check.svg";
 import { AssigneeSectionProps } from "@/types/inquiryTypes";
 
-const getAssigneeTextColor = (
-  isPendingState: boolean,
-  isConfirmed: boolean
-) => {
+const getAssigneeTextColor = (isPendingState: boolean, isChecked: boolean) => {
   if (isPendingState) return "text-point-yellow";
-  if (isConfirmed) return "text-state-done-03";
+  if (isChecked) return "text-state-done-03";
   return "text-gray-50";
 };
 
 const AssigneeSection = ({
   assignees,
   observers,
-  // confirmedAssignees, 커밋용 임시 주석 처리
   isPendingState,
-  isAssigneeEditMode,
-  showAssigneeFeatures,
 }: AssigneeSectionProps) => {
   return (
     <div className="px-[16px] flex flex-col justify-start items-start gap-[16px]">
@@ -35,9 +29,9 @@ const AssigneeSection = ({
         </div>
         <div className="w-[728px] px-[8px] py-[4px] bg-white rounded-[5px] flex justify-start items-center gap-[16px]">
           {assignees?.map(assignee => {
-            const isConfirmed = assignee.is_confirmed;
+            const isChecked = assignee.is_checked;
 
-            const textColor = getAssigneeTextColor(isPendingState, isConfirmed);
+            const textColor = getAssigneeTextColor(isPendingState, isChecked);
 
             return (
               <div
@@ -48,19 +42,19 @@ const AssigneeSection = ({
                   {assignee.profile_image_url ? (
                     <img
                       src={assignee.profile_image_url}
-                      alt={`${assignee.username}의 프로필 이미지`}
+                      alt={`${assignee.user_name}의 프로필 이미지`}
                       className="w-[20px] h-[20px] rounded-full"
                     />
                   ) : (
                     <ProfileIcon className="w-[20px] h-[20px] rounded-full text-gray-30" />
                   )}
                   <div className={`justify-start ${textColor} text-body2`}>
-                    {assignee.username}
+                    {assignee.user_name}
                   </div>
                 </div>
                 {!isPendingState && (
                   <div className="w-[20px] h-[20px] relative overflow-hidden">
-                    {isConfirmed ? (
+                    {isChecked ? (
                       <CheckGreen className="w-[20px] h-[20px]" />
                     ) : (
                       <CheckGray className="w-[20px] h-[20px]" />
@@ -88,21 +82,21 @@ const AssigneeSection = ({
         <div className="w-[728px] px-[8px] py-[4px] bg-white rounded-[5px] flex justify-start items-center gap-[16px]">
           {observers?.map(observer => (
             <div
-              key={observer.user_id}
+              key={observer.userId}
               className="flex justify-start items-center gap-[6px]"
             >
               <div className="flex justify-start items-center gap-[8px]">
-                {observer.profile_image_url ? (
+                {observer.profileImageUrl ? (
                   <img
-                    src={observer.profile_image_url}
-                    alt={`${observer.username}의 프로필 이미지`}
+                    src={observer.profileImageUrl}
+                    alt={`${observer.userName}의 프로필 이미지`}
                     className="w-[20px] h-[20px] rounded-full"
                   />
                 ) : (
                   <ProfileIcon className="w-[20px] h-[20px] rounded-full text-gray-30" />
                 )}
                 <div className="justify-start text-gray-100 text-body2">
-                  {observer.username}
+                  {observer.userName}
                 </div>
               </div>
             </div>
@@ -113,15 +107,6 @@ const AssigneeSection = ({
           )}
         </div>
       </div>
-
-      {/* 담당자용 수정 섹션 */}
-      {showAssigneeFeatures && isAssigneeEditMode && (
-        <div className="w-full mt-4 p-4 bg-gray-10 rounded-lg">
-          <div className="text-gray-60 text-body2">
-            담당자 수정 섹션 (UI 추가 예정)
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/src/components/inquiry/detail/AssigneeSection.tsx
+++ b/src/components/inquiry/detail/AssigneeSection.tsx
@@ -15,7 +15,7 @@ const getAssigneeTextColor = (
 
 const AssigneeSection = ({
   assignees,
-  references,
+  observers,
   // confirmedAssignees, 커밋용 임시 주석 처리
   isPendingState,
   isAssigneeEditMode,
@@ -48,14 +48,14 @@ const AssigneeSection = ({
                   {assignee.profile_image_url ? (
                     <img
                       src={assignee.profile_image_url}
-                      alt={`${assignee.name}의 프로필 이미지`}
+                      alt={`${assignee.username}의 프로필 이미지`}
                       className="w-[20px] h-[20px] rounded-full"
                     />
                   ) : (
                     <ProfileIcon className="w-[20px] h-[20px] rounded-full text-gray-30" />
                   )}
                   <div className={`justify-start ${textColor} text-body2`}>
-                    {assignee.name}
+                    {assignee.username}
                   </div>
                 </div>
                 {!isPendingState && (
@@ -86,23 +86,23 @@ const AssigneeSection = ({
           <div className="text-gray-50 text-body2">답변 참조자</div>
         </div>
         <div className="w-[728px] px-[8px] py-[4px] bg-white rounded-[5px] flex justify-start items-center gap-[16px]">
-          {references?.map(reference => (
+          {observers?.map(observer => (
             <div
-              key={reference.user_id}
+              key={observer.user_id}
               className="flex justify-start items-center gap-[6px]"
             >
               <div className="flex justify-start items-center gap-[8px]">
-                {reference.profile_image_url ? (
+                {observer.profile_image_url ? (
                   <img
-                    src={reference.profile_image_url}
-                    alt={`${reference.name}의 프로필 이미지`}
+                    src={observer.profile_image_url}
+                    alt={`${observer.username}의 프로필 이미지`}
                     className="w-[20px] h-[20px] rounded-full"
                   />
                 ) : (
                   <ProfileIcon className="w-[20px] h-[20px] rounded-full text-gray-30" />
                 )}
                 <div className="justify-start text-gray-100 text-body2">
-                  {reference.name}
+                  {observer.username}
                 </div>
               </div>
             </div>

--- a/src/components/inquiry/detail/Header.tsx
+++ b/src/components/inquiry/detail/Header.tsx
@@ -5,6 +5,7 @@ const Header = ({
   isTeamEnd = false,
   isAdmin = false,
   teamInfo,
+  onDelete,
 }: HeaderProps) => {
   const { group_name, division_name, team_name } = teamInfo;
 
@@ -35,7 +36,10 @@ const Header = ({
       {/* 팀관리자 삭제 버튼 */}
       {isAdmin && (
         <div className="px-[16px] flex justify-center items-center gap-[10px]">
-          <button className="justify-start text-point-red text-body1 cursor-pointer">
+          <button
+            onClick={onDelete}
+            className="justify-start text-point-red text-body1 cursor-pointer"
+          >
             게시물 삭제
           </button>
         </div>

--- a/src/components/inquiry/detail/Header.tsx
+++ b/src/components/inquiry/detail/Header.tsx
@@ -1,13 +1,11 @@
 import { Users } from "@/assets/svgs/board";
 import { HeaderProps } from "@/types/inquiryTypes";
 
-const Header = ({ isTeamEnd = false, isAdmin = false }: HeaderProps) => {
-  const teamInfo = {
-    group_name: "경영기획 그룹",
-    division_name: "ICT 기획본부",
-    team_name: "Core 개발 2부팀",
-  };
-
+const Header = ({
+  isTeamEnd = false,
+  isAdmin = false,
+  teamInfo,
+}: HeaderProps) => {
   const { group_name, division_name, team_name } = teamInfo;
 
   return (

--- a/src/components/inquiry/detail/InquiryCard.tsx
+++ b/src/components/inquiry/detail/InquiryCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 
 import AssigneeActions from "@/components/inquiry/detail/AssigneeActions";
 import AssigneeSection from "@/components/inquiry/detail/AssigneeSection";
@@ -6,7 +6,6 @@ import InquiryContent from "@/components/inquiry/detail/InquiryContent";
 import InquiryHeader from "@/components/inquiry/detail/InquiryHeader";
 import NotificationButton from "@/components/inquiry/detail/NotificationButton";
 import PendingActions from "@/components/inquiry/detail/PendingActions";
-import { useInquiryManagementApi } from "@/hooks/inquiry/useInquiryManagementApi";
 import { useInquiryState } from "@/hooks/useInquiryState";
 import { InquiryCardProps } from "@/types/inquiryTypes";
 
@@ -14,59 +13,44 @@ const InquiryCard = ({
   inquiry,
   userRole = "default",
   currentUserId,
+  handleStartAnswer,
+  onConfirm,
+  handleDeleteInquiry,
+  handleNotify,
+  notificationSent,
+  remainingTime,
+  showEditor,
+  myComment,
 }: InquiryCardProps) => {
-  useEffect(() => {
-    console.log("InquiryCard가 받은 inquiry 객체:", inquiry);
-    console.log(">>>> is_scraped 값:", inquiry?.is_scraped);
-  }, [inquiry]);
-
-  // const { team_id } = useParams<{ team_id: string; }>();
-  const [isEditingAssignees, setIsEditingAssignees] = useState(false);
-
-  // API 훅들
-  const { putInquiryAssigneeMutation } = useInquiryManagementApi();
-
   const {
-    isAssigneeEditMode,
-    notificationSent,
-    canSendNotification,
-    remainingTime,
     permissions,
     isWriter,
     isAdmin,
     finalStateLabel,
     finalStatusConfig,
-    isPendingState,
     answersCount,
+    canSendNotification,
   } = useInquiryState(inquiry, userRole, currentUserId);
 
-  /*
-  // 담당자 수정 핸들러
-  const handleUpdateAssignees = async (assigneeIds: number[]) => {
-    if (!team_id) return;
-    
-    try {
-      await putInquiryAssigneeMutation.mutateAsync({
-        team_id: Number(team_id),
-        inquiry_id: inquiry.inquiry_id,
-        data: { assignee_ids: assigneeIds }
-      });
-      setIsEditingAssignees(false);
-    } catch (error) {
-      console.error('담당자 수정 실패:', error);
-    }
-  };
-*/
+  // 담당자 정렬 로직
+  const sortedAssignees = useMemo(() => {
+    if (!inquiry.assignees) return [];
+    return [...inquiry.assignees].sort((a, b) => {
+      return Number(b.is_checked) - Number(a.is_checked);
+    });
+  }, [inquiry.assignees]);
 
-  // 버튼 표시 여부 확인
+  // 현재 유저 확인 상태
+  const isCurrentUserConfirmed = !!inquiry.assignees.find(
+    assignee => assignee.user_id === currentUserId && assignee.is_checked
+  );
+
   const showButtons =
     permissions.showAssigneeFeatures ||
-    (isWriter && !["답변 완료", "등록 보류"].includes(finalStateLabel)) ||
-    (isWriter && isPendingState);
+    (isWriter && !["답변 완료", "등록 보류"].includes(finalStateLabel));
 
   return (
     <div className="relative self-stretch p-[64px] bg-white rounded-[15px] flex flex-col justify-start items-start gap-[32px]">
-      {/* 헤더 - 상태 및 액션 버튼 */}
       <InquiryHeader
         finalStateLabel={finalStateLabel}
         finalStatusConfig={finalStatusConfig}
@@ -75,8 +59,6 @@ const InquiryCard = ({
         canSendNotification={canSendNotification}
         inquiry={inquiry}
       />
-
-      {/* 본문 */}
       <InquiryContent
         title={inquiry.title}
         content={inquiry.content}
@@ -85,70 +67,39 @@ const InquiryCard = ({
         isWriter={isWriter}
         isAdmin={isAdmin}
         answersCount={answersCount}
+        onDelete={handleDeleteInquiry}
       />
-
-      {/* 구분선 */}
       <div className="self-stretch h-0 border-t border-gray-10" />
-
-      {/* 담당자 정보 */}
       <AssigneeSection
-        assignees={inquiry.assignees}
+        assignees={sortedAssignees}
         observers={inquiry.observers}
-        confirmedAssignees={inquiry.confirmed_assignees}
-        isPendingState={isPendingState}
-        isAssigneeEditMode={isAssigneeEditMode}
-        showAssigneeFeatures={permissions.showAssigneeFeatures}
+        isPendingState={finalStateLabel === "등록 보류"}
       />
-
-      {/* 담당자 수정은 별도 영역에서 처리 */}
-      {permissions.showAssigneeFeatures && (
-        <div className="w-full">
-          <button
-            onClick={() => setIsEditingAssignees(!isEditingAssignees)}
-            disabled={putInquiryAssigneeMutation.isPending}
-            className="text-body2 text-main hover:text-main/80 transition-colors disabled:opacity-50"
-          >
-            {putInquiryAssigneeMutation.isPending ? "수정중..." : "담당자 수정"}
-          </button>
-          {isEditingAssignees && (
-            <div className="mt-4 p-4 border rounded-lg">
-              <p className="text-body2 text-gray-60 mb-4">
-                담당자 수정 기능은 구현 예정입니다.
-              </p>
-              <button
-                onClick={() => setIsEditingAssignees(false)}
-                className="text-body2 text-gray-50"
-              >
-                취소
-              </button>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* 버튼들 - 조건부 렌더링 */}
       {showButtons &&
         (permissions.showAssigneeFeatures ? (
           <AssigneeActions
             showAssigneeFeatures={permissions.showAssigneeFeatures}
+            onStartAnswer={handleStartAnswer}
+            onConfirm={onConfirm}
+            isCurrentUserConfirmed={isCurrentUserConfirmed}
+            showEditor={showEditor}
+            hasMyComment={!!myComment}
           />
         ) : (
           <div className="w-full flex justify-between items-center">
-            {/* 문의자용 담당자 알림 발송 버튼 */}
             <div className="flex justify-start">
               <NotificationButton
                 isWriter={isWriter}
                 notificationSent={notificationSent}
                 remainingTime={remainingTime}
                 finalStateLabel={finalStateLabel}
+                onSend={handleNotify}
               />
             </div>
-
-            {/* 문의자 등록 보류 상태 버튼들 */}
             <div className="flex justify-end">
               <PendingActions
                 isWriter={isWriter}
-                isPendingState={isPendingState}
+                isPendingState={finalStateLabel === "등록 보류"}
               />
             </div>
           </div>

--- a/src/components/inquiry/detail/InquiryCard.tsx
+++ b/src/components/inquiry/detail/InquiryCard.tsx
@@ -1,9 +1,12 @@
+import { useEffect, useState } from "react";
+
 import AssigneeActions from "@/components/inquiry/detail/AssigneeActions";
 import AssigneeSection from "@/components/inquiry/detail/AssigneeSection";
 import InquiryContent from "@/components/inquiry/detail/InquiryContent";
 import InquiryHeader from "@/components/inquiry/detail/InquiryHeader";
 import NotificationButton from "@/components/inquiry/detail/NotificationButton";
 import PendingActions from "@/components/inquiry/detail/PendingActions";
+import { useInquiryManagementApi } from "@/hooks/inquiry/useInquiryManagementApi";
 import { useInquiryState } from "@/hooks/useInquiryState";
 import { InquiryCardProps } from "@/types/inquiryTypes";
 
@@ -12,6 +15,17 @@ const InquiryCard = ({
   userRole = "default",
   currentUserId,
 }: InquiryCardProps) => {
+  useEffect(() => {
+    console.log("InquiryCard가 받은 inquiry 객체:", inquiry);
+    console.log(">>>> is_scraped 값:", inquiry?.is_scraped);
+  }, [inquiry]);
+
+  // const { team_id } = useParams<{ team_id: string; }>();
+  const [isEditingAssignees, setIsEditingAssignees] = useState(false);
+
+  // API 훅들
+  const { putInquiryAssigneeMutation } = useInquiryManagementApi();
+
   const {
     isAssigneeEditMode,
     notificationSent,
@@ -26,6 +40,24 @@ const InquiryCard = ({
     answersCount,
   } = useInquiryState(inquiry, userRole, currentUserId);
 
+  /*
+  // 담당자 수정 핸들러
+  const handleUpdateAssignees = async (assigneeIds: number[]) => {
+    if (!team_id) return;
+    
+    try {
+      await putInquiryAssigneeMutation.mutateAsync({
+        team_id: Number(team_id),
+        inquiry_id: inquiry.inquiry_id,
+        data: { assignee_ids: assigneeIds }
+      });
+      setIsEditingAssignees(false);
+    } catch (error) {
+      console.error('담당자 수정 실패:', error);
+    }
+  };
+*/
+
   // 버튼 표시 여부 확인
   const showButtons =
     permissions.showAssigneeFeatures ||
@@ -33,7 +65,7 @@ const InquiryCard = ({
     (isWriter && isPendingState);
 
   return (
-    <div className="self-stretch p-[64px] bg-white rounded-[15px] flex flex-col justify-start items-start gap-[32px]">
+    <div className="relative self-stretch p-[64px] bg-white rounded-[15px] flex flex-col justify-start items-start gap-[32px]">
       {/* 헤더 - 상태 및 액션 버튼 */}
       <InquiryHeader
         finalStateLabel={finalStateLabel}
@@ -41,14 +73,14 @@ const InquiryCard = ({
         isWriter={isWriter}
         isAdmin={isAdmin}
         canSendNotification={canSendNotification}
-        isScrapped={inquiry.is_scrapped}
+        inquiry={inquiry}
       />
 
       {/* 본문 */}
       <InquiryContent
         title={inquiry.title}
         content={inquiry.content}
-        writer={inquiry.writer}
+        author={inquiry.author}
         createdAt={inquiry.created_at}
         isWriter={isWriter}
         isAdmin={isAdmin}
@@ -61,12 +93,38 @@ const InquiryCard = ({
       {/* 담당자 정보 */}
       <AssigneeSection
         assignees={inquiry.assignees}
-        references={inquiry.references}
+        observers={inquiry.observers}
         confirmedAssignees={inquiry.confirmed_assignees}
         isPendingState={isPendingState}
         isAssigneeEditMode={isAssigneeEditMode}
         showAssigneeFeatures={permissions.showAssigneeFeatures}
       />
+
+      {/* 담당자 수정은 별도 영역에서 처리 */}
+      {permissions.showAssigneeFeatures && (
+        <div className="w-full">
+          <button
+            onClick={() => setIsEditingAssignees(!isEditingAssignees)}
+            disabled={putInquiryAssigneeMutation.isPending}
+            className="text-body2 text-main hover:text-main/80 transition-colors disabled:opacity-50"
+          >
+            {putInquiryAssigneeMutation.isPending ? "수정중..." : "담당자 수정"}
+          </button>
+          {isEditingAssignees && (
+            <div className="mt-4 p-4 border rounded-lg">
+              <p className="text-body2 text-gray-60 mb-4">
+                담당자 수정 기능은 구현 예정입니다.
+              </p>
+              <button
+                onClick={() => setIsEditingAssignees(false)}
+                className="text-body2 text-gray-50"
+              >
+                취소
+              </button>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* 버튼들 - 조건부 렌더링 */}
       {showButtons &&

--- a/src/components/inquiry/detail/InquiryContent.tsx
+++ b/src/components/inquiry/detail/InquiryContent.tsx
@@ -5,7 +5,7 @@ import { InquiryContentProps } from "@/types/inquiryTypes";
 const InquiryContent = ({
   title,
   content,
-  writer,
+  author,
   createdAt,
   isWriter,
   isAdmin,
@@ -29,18 +29,18 @@ const InquiryContent = ({
       <div className="self-stretch rounded-[30px] flex flex-col justify-center items-start gap-4">
         <div className="flex justify-between items-center w-full">
           <div className="flex items-center gap-2">
-            {writer.profile_image_url ? (
+            {author.profile_image_url ? (
               <img
-                src={writer.profile_image_url}
-                alt={`${writer.name}의 프로필 이미지`}
+                src={author.profile_image_url}
+                alt={`${author.username}의 프로필 이미지`}
                 className="w-[20px] h-[20px] rounded-full"
               />
             ) : (
               <ProfileIcon className="w-[20px] h-[20px] rounded-full text-gray-30" />
             )}
-            <div className="text-gray-80 text-body1-b">{writer.name}</div>
+            <div className="text-gray-80 text-body1-b">{author.username}</div>
             <div className="text-main text-detail1-b mt-[1px]">
-              {writer.team_name}
+              {author.teamname}
             </div>
           </div>
           {/* 문의자 수정/삭제 버튼 */}

--- a/src/components/inquiry/detail/InquiryContent.tsx
+++ b/src/components/inquiry/detail/InquiryContent.tsx
@@ -1,3 +1,5 @@
+import { useNavigate, useParams } from "react-router-dom";
+
 import ProfileIcon from "@/assets/svgs/inquiry/detail/profile.svg";
 import { formatDateToKorean } from "@/utils/dateUtils";
 import { InquiryContentProps } from "@/types/inquiryTypes";
@@ -10,7 +12,19 @@ const InquiryContent = ({
   isWriter,
   isAdmin,
   answersCount,
+  onDelete,
 }: InquiryContentProps) => {
+  const navigate = useNavigate();
+  const { team_id, inquiry_id } = useParams<{
+    team_id: string;
+    inquiry_id: string;
+  }>();
+
+  // 수정 페이지로 이동하는 핸들러
+  const handleEdit = () => {
+    navigate(`/teams/${team_id}/inquiries/${inquiry_id}/edit`);
+  };
+
   return (
     <div className="self-stretch px-[16px] flex flex-col justify-start items-start gap-[32px]">
       {/* 제목 */}
@@ -32,24 +46,33 @@ const InquiryContent = ({
             {author.profile_image_url ? (
               <img
                 src={author.profile_image_url}
-                alt={`${author.username}의 프로필 이미지`}
+                alt={`${author.user_name}의 프로필 이미지`}
                 className="w-[20px] h-[20px] rounded-full"
               />
             ) : (
               <ProfileIcon className="w-[20px] h-[20px] rounded-full text-gray-30" />
             )}
-            <div className="text-gray-80 text-body1-b">{author.username}</div>
+            <div className="text-gray-80 text-body1-b">{author.user_name}</div>
             <div className="text-main text-detail1-b mt-[1px]">
-              {author.teamname}
+              {author.team_name}
             </div>
           </div>
           {/* 문의자 수정/삭제 버튼 */}
           {isWriter && (
             <div className="flex items-center gap-4">
-              <button className="text-gray-50 text-body2">수정</button>
-              {/* 답변이 없거나 관리자가 아닌 경우에만 삭제 버튼 표시 */}
+              <button
+                onClick={handleEdit}
+                className="text-gray-50 text-body2 cursor-pointer"
+              >
+                수정
+              </button>
               {(answersCount === 0 || isAdmin) && (
-                <button className="text-gray-50 text-body2">삭제</button>
+                <button
+                  onClick={onDelete}
+                  className="text-gray-50 text-body2 cursor-pointer"
+                >
+                  삭제
+                </button>
               )}
             </div>
           )}

--- a/src/components/inquiry/detail/InquiryHeader.tsx
+++ b/src/components/inquiry/detail/InquiryHeader.tsx
@@ -1,10 +1,8 @@
-import { useState } from "react";
-
-import Bell from "@/assets/svgs/inquiry/detail/bell.svg";
 import BellOff from "@/assets/svgs/inquiry/detail/bell-off.svg";
 import BellOn from "@/assets/svgs/inquiry/detail/bell-on.svg";
 import Star from "@/assets/svgs/inquiry/detail/star.svg";
 import StarActive from "@/assets/svgs/inquiry/detail/star-active.svg";
+import { useScrapApi } from "@/hooks/scrap/useScrapApi";
 import { InquiryHeaderProps } from "@/types/inquiryTypes";
 
 const InquiryHeader = ({
@@ -13,14 +11,23 @@ const InquiryHeader = ({
   isWriter,
   isAdmin,
   canSendNotification,
-  isScrapped: isScrappedProp,
+  inquiry,
 }: InquiryHeaderProps) => {
-  // 스크랩 상태 관리
-  const [isScrapped, setIsScrapped] = useState(isScrappedProp);
+  const { postScrapMutation, deleteScrapMutation } = useScrapApi();
 
-  // 스크랩 토글 함수
-  const handleScrapClick = () => {
-    setIsScrapped(!isScrapped);
+  // 스크랩 토글 핸들러
+  const handleToggleScrap = async () => {
+    try {
+      if (inquiry.is_scraped || false) {
+        await deleteScrapMutation.mutateAsync({
+          inquiry_id: inquiry.inquiry_id,
+        });
+      } else {
+        await postScrapMutation.mutateAsync({ inquiry_id: inquiry.inquiry_id });
+      }
+    } catch (error) {
+      console.error("스크랩 처리 실패:", error);
+    }
   };
 
   return (
@@ -41,7 +48,7 @@ const InquiryHeader = ({
         {/* 기본 알림 버튼 (문의자가 아닌 경우에만) */}
         {!isWriter && !isAdmin && (
           <button className="w-[20px] h-[20px] relative cursor-pointer">
-            <Bell className="text-gray-30" />
+            <BellOff className="text-gray-30" />
           </button>
         )}
 
@@ -62,11 +69,15 @@ const InquiryHeader = ({
         {/* 스크랩 버튼 (팀관리자가 아닌 경우에만) */}
         {!isAdmin && (
           <button
-            onClick={handleScrapClick}
+            onClick={handleToggleScrap}
             className="w-[20px] h-[20px] relative overflow-hidden cursor-pointer"
-            aria-label={isScrapped ? "스크랩 취소" : "스크랩"}
+            aria-label={inquiry.is_scraped || false ? "스크랩 취소" : "스크랩"}
           >
-            {isScrapped ? <StarActive /> : <Star className="text-gray-50" />}
+            {inquiry.is_scraped || false ? (
+              <StarActive />
+            ) : (
+              <Star className="text-gray-50" />
+            )}
           </button>
         )}
       </div>

--- a/src/components/inquiry/detail/NotificationButton.tsx
+++ b/src/components/inquiry/detail/NotificationButton.tsx
@@ -7,6 +7,7 @@ const NotificationButton = ({
   notificationSent,
   remainingTime,
   finalStateLabel,
+  onSend,
 }: NotificationButtonProps) => {
   // 문의자가 아니거나, 답변완료/등록보류 상태면 표시하지 않음
   if (!isWriter || ["답변 완료", "등록 보류"].includes(finalStateLabel)) {
@@ -16,14 +17,16 @@ const NotificationButton = ({
   return (
     <div className="flex justify-start items-start">
       {notificationSent ? (
-        // 알림 보낸 후
         <Button buttonType="done" className="border-gray-20 text-gray-60">
           <Bell className="w-[20px] h-[20px] text-gray-60" />
           <span>담당자 알림 발송 ({remainingTime || "대기중"})</span>
         </Button>
       ) : (
-        // 알림 보내기 전
-        <Button buttonType="default" className="text-gray-80 hover:bg-gray-10">
+        <Button
+          onClick={onSend}
+          buttonType="default"
+          className="text-gray-80 hover:bg-gray-10"
+        >
           <Bell className="w-[20px] h-[20px] text-gray-60" />
           <span>담당자 알림 발송</span>
         </Button>

--- a/src/components/inquiry/detail/answer/AnswerEditor.tsx
+++ b/src/components/inquiry/detail/answer/AnswerEditor.tsx
@@ -1,0 +1,83 @@
+import { useEffect } from "react";
+
+import Pencil from "@/assets/svgs/inquiry/pencil.svg";
+import Button from "@/components/common/Button";
+import EditorToolbar from "@/components/inquiry/form/EditorToolbar";
+import FileUploadBox from "@/components/inquiry/form/FileUploadBox";
+import { useEditor } from "@/hooks/useEditor";
+import { AnswerEditorProps } from "@/types/inquiryTypes";
+
+import "@toast-ui/editor/dist/toastui-editor.css";
+import { Editor } from "@toast-ui/react-editor";
+
+const AnswerEditor = ({
+  initialContent,
+  onContentChange,
+  onSubmit,
+}: AnswerEditorProps) => {
+  const { editorRef, fileInputRef, activeSet, execCommand, handleFileChange } =
+    useEditor();
+
+  // 내용 변경 감지 및 부모 컴포넌트로 전파
+  useEffect(() => {
+    const instance = editorRef.current?.getInstance();
+    if (!instance) return;
+
+    // 초기값 설정
+    if (instance.getMarkdown() !== initialContent) {
+      instance.setMarkdown(initialContent);
+    }
+
+    const handleChange = () => {
+      onContentChange(instance.getMarkdown());
+    };
+
+    instance.on("change", handleChange);
+    return () => {
+      instance.off("change");
+    };
+  }, [initialContent, onContentChange, editorRef]);
+
+  const handleSubmit = () => {
+    const content = editorRef.current?.getInstance().getMarkdown() || "";
+    // 파일 상태는 FileUploadBox가 자체적으로 관리하므로 여기서는 전달하지 않음
+    onSubmit(content);
+  };
+
+  return (
+    <div className="w-full flex flex-col gap-8">
+      <div className="flex flex-col gap-2 px-4">
+        <EditorToolbar
+          activeSet={activeSet}
+          execCommand={execCommand}
+          fileInputRef={fileInputRef}
+          handleFileChange={handleFileChange}
+        />
+        <Editor
+          ref={editorRef}
+          initialValue={initialContent}
+          placeholder="답변 내용을 입력하세요."
+          previewStyle="vertical"
+          height="auto"
+          minHeight="300px"
+          initialEditType="wysiwyg"
+          hideModeSwitch={true}
+          toolbarItems={[]}
+          language="ko-KR"
+        />
+      </div>
+      <FileUploadBox />
+      <div className="flex justify-end gap-4">
+        <Button buttonType="default" className="text-gray-80">
+          임시저장
+        </Button>
+        <Button buttonType="blue" onClick={handleSubmit}>
+          <Pencil />
+          <span className="text-heading3 text-white">답변 등록하기</span>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default AnswerEditor;

--- a/src/components/inquiry/detail/answer/AnswerItem.tsx
+++ b/src/components/inquiry/detail/answer/AnswerItem.tsx
@@ -13,7 +13,7 @@ const AnswerItem = ({
   isOnlyComment,
   currentUserId,
 }: AnswerItemProps) => {
-  const isWriter = comment.writer.user_id === currentUserId;
+  const isWriter = comment.author?.user_id === currentUserId;
 
   return (
     <div className="flex flex-col gap-8 pt-8">
@@ -21,46 +21,48 @@ const AnswerItem = ({
         {comment.content}
       </div>
 
-      <div className="flex flex-col gap-4 rounded-[30px] px-4">
-        <div className="flex w-full items-start justify-between">
-          <div className="flex items-center gap-[10px]">
-            <div className="flex items-center gap-2">
-              {comment.writer.profile_image_url ? (
-                <img
-                  src={comment.writer.profile_image_url}
-                  alt={`${comment.writer.name}의 프로필 이미지`}
-                  className="h-5 w-5 rounded-full"
-                />
-              ) : (
-                <ProfileIcon className="h-5 w-5 rounded-full text-gray-30" />
+      {comment.author && (
+        <div className="flex flex-col gap-4 rounded-[30px] px-4">
+          <div className="flex w-full items-start justify-between">
+            <div className="flex items-center gap-[10px]">
+              <div className="flex items-center gap-2">
+                {comment.author.profile_image_url ? (
+                  <img
+                    src={comment.author.profile_image_url}
+                    alt={`${comment.author.username}의 프로필 이미지`}
+                    className="h-5 w-5 rounded-full"
+                  />
+                ) : (
+                  <ProfileIcon className="h-5 w-5 rounded-full text-gray-30" />
+                )}
+                <span className="text-body1-b text-gray-80">
+                  {comment.author.username}
+                </span>
+              </div>
+              {comment.author.team_name && (
+                <span className="text-detail1-b text-main mt-[1px]">
+                  {comment.author.team_name}
+                </span>
               )}
-              <span className="text-body1-b text-gray-80">
-                {comment.writer.name}
-              </span>
             </div>
-            {comment.writer.team_name && (
-              <span className="text-detail1-b text-main mt-[1px]">
-                {comment.writer.team_name}
-              </span>
+
+            {isWriter && (
+              <div className="flex items-center gap-8">
+                <button className="text-body2 text-gray-50">수정</button>
+                <button
+                  disabled={isOnlyComment}
+                  className="text-body2 text-gray-50 disabled:cursor-not-allowed disabled:text-gray-30"
+                >
+                  삭제
+                </button>
+              </div>
             )}
           </div>
-
-          {isWriter && (
-            <div className="flex items-center gap-8">
-              <button className="text-body2 text-gray-50">수정</button>
-              <button
-                disabled={isOnlyComment}
-                className="text-body2 text-gray-50 disabled:cursor-not-allowed disabled:text-gray-30"
-              >
-                삭제
-              </button>
-            </div>
-          )}
+          <div className="text-detail1 text-gray-50">
+            {formatDateToKorean(comment.created_at, { showTime: true })}
+          </div>
         </div>
-        <div className="text-detail1 text-gray-50">
-          {formatDateToKorean(comment.created_at, { showTime: true })}
-        </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/components/inquiry/detail/answer/AnswerItem.tsx
+++ b/src/components/inquiry/detail/answer/AnswerItem.tsx
@@ -1,68 +1,73 @@
 import ProfileIcon from "@/assets/svgs/inquiry/detail/profile.svg";
 import { formatDateToKorean } from "@/utils/dateUtils";
-import type { Comment } from "@/types/inquiryTypes";
-
-interface AnswerItemProps {
-  comment: Comment;
-  isOnlyComment: boolean;
-  currentUserId?: number;
-}
+import type { AnswerItemProps } from "@/types/inquiryTypes";
 
 const AnswerItem = ({
   comment,
   isOnlyComment,
   currentUserId,
+  onStartEdit,
+  onDelete,
 }: AnswerItemProps) => {
-  const isWriter = comment.author?.user_id === currentUserId;
+  const isWriter = comment.user?.user_id === currentUserId;
+
+  if (!comment.user) return null;
 
   return (
-    <div className="flex flex-col gap-8 pt-8">
-      <div className="whitespace-pre-line px-4 text-body2 text-gray-100">
+    <div className="flex w-full flex-col gap-8">
+      <div className="whitespace-pre-line px-4 py-8 text-body2 text-gray-100">
         {comment.content}
       </div>
-
-      {comment.author && (
-        <div className="flex flex-col gap-4 rounded-[30px] px-4">
-          <div className="flex w-full items-start justify-between">
-            <div className="flex items-center gap-[10px]">
-              <div className="flex items-center gap-2">
-                {comment.author.profile_image_url ? (
-                  <img
-                    src={comment.author.profile_image_url}
-                    alt={`${comment.author.username}의 프로필 이미지`}
-                    className="h-5 w-5 rounded-full"
-                  />
-                ) : (
-                  <ProfileIcon className="h-5 w-5 rounded-full text-gray-30" />
-                )}
-                <span className="text-body1-b text-gray-80">
-                  {comment.author.username}
-                </span>
-              </div>
-              {comment.author.team_name && (
-                <span className="text-detail1-b text-main mt-[1px]">
-                  {comment.author.team_name}
-                </span>
+      {/* 작성자 정보 */}
+      <div className="self-stretch px-4 flex flex-col items-start justify-center gap-4">
+        <div className="flex w-full items-center justify-between">
+          {/* 작성자 프로필 */}
+          <div className="flex items-center gap-[10px]">
+            <div className="flex items-center gap-2">
+              {comment.user.profile_url ? (
+                <img
+                  src={comment.user.profile_url}
+                  alt={`${comment.user.username}의 프로필 이미지`}
+                  className="h-5 w-5 rounded-full"
+                />
+              ) : (
+                <ProfileIcon className="h-5 w-5 rounded-full text-gray-30" />
               )}
+              <span className="text-body1-b text-gray-80">
+                {comment.user.username}
+              </span>
             </div>
-
-            {isWriter && (
-              <div className="flex items-center gap-8">
-                <button className="text-body2 text-gray-50">수정</button>
-                <button
-                  disabled={isOnlyComment}
-                  className="text-body2 text-gray-50 disabled:cursor-not-allowed disabled:text-gray-30"
-                >
-                  삭제
-                </button>
-              </div>
+            {comment.user.team_name && (
+              <span className="text-detail1-b text-main mt-[1px]">
+                {comment.user.team_name}
+              </span>
             )}
           </div>
-          <div className="text-detail1 text-gray-50">
-            {formatDateToKorean(comment.created_at, { showTime: true })}
-          </div>
+
+          {/* 수정/삭제 버튼 */}
+          {isWriter && (
+            <div className="flex items-center gap-8">
+              <button
+                onClick={() => onStartEdit(comment)}
+                className="text-body2 text-gray-50 cursor-pointer"
+              >
+                수정
+              </button>
+              <button
+                disabled={isOnlyComment}
+                className="text-body2 text-gray-50 cursor-pointer"
+                onClick={() => onDelete(comment.comment_id)}
+              >
+                삭제
+              </button>
+            </div>
+          )}
         </div>
-      )}
+        {/* 작성 시간 */}
+        <div className="text-detail1 text-gray-50">
+          {formatDateToKorean(comment.created_at, { showTime: true })}
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/inquiry/detail/answer/AnswerList.tsx
+++ b/src/components/inquiry/detail/answer/AnswerList.tsx
@@ -11,8 +11,12 @@ const AnswerList = ({
   selectedCommentId,
   onSelectComment,
 }: AnswerListProps) => {
-  const uniqueCommenters = comments.reduce((acc, current) => {
-    if (!acc.find((item) => item.writer.user_id === current.writer.user_id)) {
+  const validComments = comments.filter(comment => comment && comment.author);
+
+  // 동일한 작성자의 답변이 여러 개 있을 경우 탭에는 한 번만 표시
+  const uniqueCommenters = validComments.reduce((acc, current) => {
+    // 이제 current.author는 항상 존재하므로 안전합니다.
+    if (!acc.find(item => item.author.user_id === current.author.user_id)) {
       acc.push(current);
     }
     return acc;
@@ -20,9 +24,9 @@ const AnswerList = ({
 
   return (
     <div className="flex items-center gap-6 border-b-2 border-gray-10">
-      {uniqueCommenters.map((comment) => (
+      {uniqueCommenters.map(comment => (
         <button
-          key={comment.writer.user_id}
+          key={comment.author.user_id}
           onClick={() => onSelectComment(comment.comment_id)}
           className={`border-b-2 px-6 py-4 text-heading3-b transition-colors ${
             selectedCommentId === comment.comment_id
@@ -31,7 +35,7 @@ const AnswerList = ({
           }`}
           style={{ marginBottom: "-2px" }}
         >
-          {comment.writer.name}
+          {comment.author.username}
         </button>
       ))}
     </div>

--- a/src/components/inquiry/detail/answer/AnswerList.tsx
+++ b/src/components/inquiry/detail/answer/AnswerList.tsx
@@ -1,41 +1,24 @@
-import type { Comment } from "@/types/inquiryTypes";
-
-interface AnswerListProps {
-  comments: Comment[];
-  selectedCommentId: number | null;
-  onSelectComment: (id: number) => void;
-}
+import type { AnswerListProps } from "@/types/inquiryTypes";
 
 const AnswerList = ({
-  comments,
-  selectedCommentId,
-  onSelectComment,
+  answerers,
+  selectedUserId,
+  onSelectUser,
 }: AnswerListProps) => {
-  const validComments = comments.filter(comment => comment && comment.author);
-
-  // 동일한 작성자의 답변이 여러 개 있을 경우 탭에는 한 번만 표시
-  const uniqueCommenters = validComments.reduce((acc, current) => {
-    // 이제 current.author는 항상 존재하므로 안전합니다.
-    if (!acc.find(item => item.author.user_id === current.author.user_id)) {
-      acc.push(current);
-    }
-    return acc;
-  }, [] as Comment[]);
-
   return (
-    <div className="flex items-center gap-6 border-b-2 border-gray-10">
-      {uniqueCommenters.map(comment => (
+    <div className="w-full flex items-center gap-6 border-b-2 border-gray-10">
+      {answerers.map(answerer => (
         <button
-          key={comment.author.user_id}
-          onClick={() => onSelectComment(comment.comment_id)}
+          key={answerer.user_id}
+          onClick={() => onSelectUser(answerer.user_id)}
           className={`border-b-2 px-6 py-4 text-heading3-b transition-colors ${
-            selectedCommentId === comment.comment_id
+            selectedUserId === answerer.user_id
               ? "border-main text-main"
               : "border-transparent text-gray-30"
           }`}
           style={{ marginBottom: "-2px" }}
         >
-          {comment.author.username}
+          {answerer.username}
         </button>
       ))}
     </div>

--- a/src/components/inquiry/detail/answer/AnswerSection.tsx
+++ b/src/components/inquiry/detail/answer/AnswerSection.tsx
@@ -1,138 +1,88 @@
-// src/components/inquiry/detail/answer/AnswerSection.tsx
-import { useState } from "react";
+import type { AnswerSectionProps } from "@/types/inquiryTypes";
 
-import AnswerItem from "@/components/inquiry/detail/answer/AnswerItem";
-import AnswerList from "@/components/inquiry/detail/answer/AnswerList";
-import { useAnswerApi } from "@/hooks/inquiry/useAnswerApi";
-import { useInquiryManagementApi } from "@/hooks/inquiry/useInquiryManagementApi";
-import type { Comment } from "@/types/inquiryTypes";
+import AnswerEditor from "./AnswerEditor";
+import AnswerItem from "./AnswerItem";
+import AnswerList from "./AnswerList";
 
-interface AnswerSectionProps {
-  inquiry_id: number;
-  team_id: number;
-  comments: Comment[];
-  currentUserId?: number;
-  canAnswer?: boolean;
-}
-
-const AnswerSection = ({
-  inquiry_id,
-  // team_id,
-  comments = [],
-  currentUserId,
-  canAnswer = false,
-}: AnswerSectionProps) => {
-  const [selectedCommentId, setSelectedCommentId] = useState<number | null>(
-    comments.length > 0 ? comments[0].comment_id : null
-  );
-
-  // API 훅들
+const AnswerSection = (props: AnswerSectionProps) => {
   const {
-    // postAnswerMutation,
-    // putAnswerMutation,
-    // deleteAnswerMutation,
-    postInquiryConfirmMutation,
-  } = useAnswerApi();
-  const { postInquiryNotifyMutation } = useInquiryManagementApi();
+    inquiry,
+    currentUserId,
+    showEditor,
+    tabsToDisplay,
+    selectedUserId,
+    selectedComment,
+    draftContent,
+    setDraftContent,
+    handleStartAnswer,
+    handleSelectTab,
+    onEditorSubmit,
+    onDeleteAnswer,
+  } = props;
 
-  const selectedComment = comments.find(
-    comment => comment.comment_id === selectedCommentId
-  );
-
-  // 문의 확인 처리
-  const handleConfirmInquiry = async () => {
-    if (!confirm("문의를 확인 처리하시겠습니까?")) return;
-
-    try {
-      await postInquiryConfirmMutation.mutateAsync({ inquiry_id });
-    } catch (error) {
-      console.error("문의 확인 처리 실패:", error);
-    }
-  };
-
-  // 알림 메일 발송
-  const handleNotifyAssignees = async () => {
-    if (!confirm("담당자들에게 알림 메일을 발송하시겠습니까?")) return;
-
-    try {
-      await postInquiryNotifyMutation.mutateAsync({ inquiry_id });
-      // TODO: 성공 토스트 알림
-    } catch (error) {
-      console.error("알림 메일 발송 실패:", error);
-    }
-  };
+  // 답변 섹션의 클래스를 조건부로 설정
+  const answerSectionClasses = [
+    "flex",
+    "w-full",
+    "flex-col",
+    "justify-start",
+    "items-start",
+    "rounded-[15px]",
+    "bg-white",
+    "p-14",
+    showEditor ? "border-[3px] border-main" : "border-transparent",
+  ].join(" ");
 
   return (
-    <div className="flex w-full flex-col justify-start items-start rounded-[15px] bg-white px-16 py-14 gap-6">
-      {/* 답변 유무에 따라 다른 UI를 렌더링 */}
-      {comments.length === 0 ? (
-        // ==================================================
-        // ▼▼▼ 답변이 없을 때의 UI를 명세에 맞게 재구성 ▼▼▼
-        // ==================================================
-        <div className="w-full h-[90px] flex flex-col justify-between items-start">
-          {/* 1. 답변 헤더 (개수 포함) */}
-          <div className="w-full flex items-center gap-2">
-            <h2 className="text-heading2-sb text-gray-100">답변</h2>
-            <div className="flex h-6 w-9 items-center justify-center rounded-[30px] bg-main">
-              <span className="text-body1 text-white">0</span>
-            </div>
-          </div>
-          {/* 2. "아직 답변이 달리지 않았습니다" 텍스트 */}
-          <div className="self-stretch flex flex-col items-start">
-            <p className="text-heading2-b text-gray-40">
-              아직 답변이 달리지 않았습니다!
-            </p>
+    <div className={answerSectionClasses}>
+      {/* 섹션 제목 및 답변 개수 */}
+      <div className="flex w-full items-center justify-between">
+        <div className="flex items-center justify-start gap-2">
+          <h2 className="text-heading2-sb text-gray-100">답변</h2>
+          <div className="flex h-6 w-auto min-w-[35px] items-center justify-center rounded-[30px] bg-main px-3">
+            <span className="text-body1 text-white">
+              {inquiry.answers.answers.length}
+            </span>
           </div>
         </div>
-      ) : (
-        // 답변이 있을 때의 UI
-        <>
-          <div className="flex w-full items-center justify-between">
-            <div className="flex items-center justify-start gap-2">
-              <h2 className="text-heading2-sb text-gray-100">답변</h2>
-              <div className="flex h-6 w-9 items-center justify-center rounded-[30px] bg-main">
-                <span className="text-body1 text-white">{comments.length}</span>
-              </div>
-            </div>
-            {canAnswer && (
-              <div className="flex gap-3">
-                <button
-                  onClick={handleConfirmInquiry}
-                  disabled={postInquiryConfirmMutation.isPending}
-                  className="rounded-lg bg-gray-20 px-4 py-2 text-gray-80 hover:bg-gray-30 transition-colors disabled:opacity-50"
-                >
-                  {postInquiryConfirmMutation.isPending
-                    ? "처리중..."
-                    : "확인 처리"}
-                </button>
-                <button
-                  onClick={handleNotifyAssignees}
-                  disabled={postInquiryNotifyMutation.isPending}
-                  className="rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 transition-colors disabled:opacity-50"
-                >
-                  {postInquiryNotifyMutation.isPending
-                    ? "발송중..."
-                    : "알림 발송"}
-                </button>
-              </div>
-            )}
+      </div>
+
+      {/* [수정] 답변 탭과 내용을 하나의 div로 묶고, 헤더와의 간격을 mt-6으로 설정 */}
+      <div className="w-full mt-6">
+        {/* 답변자 탭 목록 */}
+        {tabsToDisplay.length > 0 && !showEditor && (
+          <AnswerList
+            answerers={tabsToDisplay}
+            selectedUserId={selectedUserId}
+            onSelectUser={handleSelectTab}
+          />
+        )}
+
+        {/* 답변 내용 */}
+        {showEditor ? (
+          <AnswerEditor
+            initialContent={draftContent}
+            onContentChange={setDraftContent}
+            onSubmit={onEditorSubmit}
+          />
+        ) : selectedComment ? (
+          <AnswerItem
+            comment={selectedComment}
+            isOnlyComment={inquiry.answers.answers.length === 1}
+            currentUserId={currentUserId}
+            onStartEdit={handleStartAnswer}
+            onDelete={onDeleteAnswer}
+          />
+        ) : (
+          <div className="w-full h-[90px] flex flex-col justify-center items-start">
+            <p className="text-heading2-b text-gray-40">
+              {inquiry.answers.count === 0
+                ? "아직 답변이 달리지 않았습니다!"
+                : "표시할 답변이 없습니다."}
+            </p>
           </div>
-          <div className="mt-4 flex flex-col w-full">
-            <AnswerList
-              comments={comments}
-              selectedCommentId={selectedCommentId}
-              onSelectComment={setSelectedCommentId}
-            />
-            {selectedComment && (
-              <AnswerItem
-                comment={selectedComment}
-                isOnlyComment={comments.length === 1}
-                currentUserId={currentUserId}
-              />
-            )}
-          </div>
-        </>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/inquiry/detail/answer/AnswerSection.tsx
+++ b/src/components/inquiry/detail/answer/AnswerSection.tsx
@@ -18,6 +18,7 @@ const AnswerSection = (props: AnswerSectionProps) => {
     handleSelectTab,
     onEditorSubmit,
     onDeleteAnswer,
+    isWritingAnswer,
   } = props;
 
   // 답변 섹션의 클래스를 조건부로 설정
@@ -33,6 +34,10 @@ const AnswerSection = (props: AnswerSectionProps) => {
     showEditor ? "border-[3px] border-main" : "border-transparent",
   ].join(" ");
 
+  // 현재 선택된 사용자가 내 자신이고 답변 작성 중인지 확인
+  const isMyTabAndWriting =
+    selectedUserId === currentUserId && (showEditor || isWritingAnswer);
+
   return (
     <div className={answerSectionClasses}>
       {/* 섹션 제목 및 답변 개수 */}
@@ -46,11 +51,9 @@ const AnswerSection = (props: AnswerSectionProps) => {
           </div>
         </div>
       </div>
-
-      {/* [수정] 답변 탭과 내용을 하나의 div로 묶고, 헤더와의 간격을 mt-6으로 설정 */}
       <div className="w-full mt-6">
-        {/* 답변자 탭 목록 */}
-        {tabsToDisplay.length > 0 && !showEditor && (
+        {/* 답변자 탭 목록 - 답변이 있거나 답변 작성 중일 때 표시 */}
+        {tabsToDisplay.length > 0 && (
           <AnswerList
             answerers={tabsToDisplay}
             selectedUserId={selectedUserId}
@@ -59,13 +62,15 @@ const AnswerSection = (props: AnswerSectionProps) => {
         )}
 
         {/* 답변 내용 */}
-        {showEditor ? (
+        {isMyTabAndWriting ? (
+          // 내 탭이 선택되고 답변 작성 중인 경우 에디터 표시
           <AnswerEditor
             initialContent={draftContent}
             onContentChange={setDraftContent}
             onSubmit={onEditorSubmit}
           />
         ) : selectedComment ? (
+          // 선택된 답변이 있는 경우 답변 아이템 표시
           <AnswerItem
             comment={selectedComment}
             isOnlyComment={inquiry.answers.answers.length === 1}
@@ -74,6 +79,7 @@ const AnswerSection = (props: AnswerSectionProps) => {
             onDelete={onDeleteAnswer}
           />
         ) : (
+          // 답변이 없는 경우 빈 상태 메시지 표시
           <div className="w-full h-[90px] flex flex-col justify-center items-start">
             <p className="text-heading2-b text-gray-40">
               {inquiry.answers.count === 0

--- a/src/components/inquiry/detail/answer/AnswerSection.tsx
+++ b/src/components/inquiry/detail/answer/AnswerSection.tsx
@@ -1,53 +1,137 @@
+// src/components/inquiry/detail/answer/AnswerSection.tsx
 import { useState } from "react";
 
 import AnswerItem from "@/components/inquiry/detail/answer/AnswerItem";
 import AnswerList from "@/components/inquiry/detail/answer/AnswerList";
+import { useAnswerApi } from "@/hooks/inquiry/useAnswerApi";
+import { useInquiryManagementApi } from "@/hooks/inquiry/useInquiryManagementApi";
 import type { Comment } from "@/types/inquiryTypes";
 
 interface AnswerSectionProps {
+  inquiry_id: number;
+  team_id: number;
   comments: Comment[];
   currentUserId?: number;
+  canAnswer?: boolean;
 }
 
-const AnswerSection = ({ comments, currentUserId }: AnswerSectionProps) => {
+const AnswerSection = ({
+  inquiry_id,
+  // team_id,
+  comments = [],
+  currentUserId,
+  canAnswer = false,
+}: AnswerSectionProps) => {
   const [selectedCommentId, setSelectedCommentId] = useState<number | null>(
     comments.length > 0 ? comments[0].comment_id : null
   );
+
+  // API 훅들
+  const {
+    // postAnswerMutation,
+    // putAnswerMutation,
+    // deleteAnswerMutation,
+    postInquiryConfirmMutation,
+  } = useAnswerApi();
+  const { postInquiryNotifyMutation } = useInquiryManagementApi();
 
   const selectedComment = comments.find(
     comment => comment.comment_id === selectedCommentId
   );
 
-  return (
-    <div className="flex w-full flex-col justify-between items-start rounded-[15px] bg-white p-14">
-      <div className="flex items-center justify-start gap-2">
-        <h2 className="text-heading2-sb text-gray-100">답변</h2>
-        <div className="flex h-6 w-9 items-center justify-center rounded-[30px] bg-main">
-          <span className="text-body1 text-white">{comments.length}</span>
-        </div>
-      </div>
+  // 문의 확인 처리
+  const handleConfirmInquiry = async () => {
+    if (!confirm("문의를 확인 처리하시겠습니까?")) return;
 
+    try {
+      await postInquiryConfirmMutation.mutateAsync({ inquiry_id });
+    } catch (error) {
+      console.error("문의 확인 처리 실패:", error);
+    }
+  };
+
+  // 알림 메일 발송
+  const handleNotifyAssignees = async () => {
+    if (!confirm("담당자들에게 알림 메일을 발송하시겠습니까?")) return;
+
+    try {
+      await postInquiryNotifyMutation.mutateAsync({ inquiry_id });
+      // TODO: 성공 토스트 알림
+    } catch (error) {
+      console.error("알림 메일 발송 실패:", error);
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col justify-start items-start rounded-[15px] bg-white px-16 py-14 gap-6">
+      {/* 답변 유무에 따라 다른 UI를 렌더링 */}
       {comments.length === 0 ? (
-        <div className="mt-8">
-          <p className="text-heading2-b text-gray-40">
-            아직 답변이 달리지 않았습니다!
-          </p>
+        // ==================================================
+        // ▼▼▼ 답변이 없을 때의 UI를 명세에 맞게 재구성 ▼▼▼
+        // ==================================================
+        <div className="w-full h-[90px] flex flex-col justify-between items-start">
+          {/* 1. 답변 헤더 (개수 포함) */}
+          <div className="w-full flex items-center gap-2">
+            <h2 className="text-heading2-sb text-gray-100">답변</h2>
+            <div className="flex h-6 w-9 items-center justify-center rounded-[30px] bg-main">
+              <span className="text-body1 text-white">0</span>
+            </div>
+          </div>
+          {/* 2. "아직 답변이 달리지 않았습니다" 텍스트 */}
+          <div className="self-stretch flex flex-col items-start">
+            <p className="text-heading2-b text-gray-40">
+              아직 답변이 달리지 않았습니다!
+            </p>
+          </div>
         </div>
       ) : (
-        <div className="mt-4 flex flex-col">
-          <AnswerList
-            comments={comments}
-            selectedCommentId={selectedCommentId}
-            onSelectComment={setSelectedCommentId}
-          />
-          {selectedComment && (
-            <AnswerItem
-              comment={selectedComment}
-              isOnlyComment={comments.length === 1}
-              currentUserId={currentUserId}
+        // 답변이 있을 때의 UI
+        <>
+          <div className="flex w-full items-center justify-between">
+            <div className="flex items-center justify-start gap-2">
+              <h2 className="text-heading2-sb text-gray-100">답변</h2>
+              <div className="flex h-6 w-9 items-center justify-center rounded-[30px] bg-main">
+                <span className="text-body1 text-white">{comments.length}</span>
+              </div>
+            </div>
+            {canAnswer && (
+              <div className="flex gap-3">
+                <button
+                  onClick={handleConfirmInquiry}
+                  disabled={postInquiryConfirmMutation.isPending}
+                  className="rounded-lg bg-gray-20 px-4 py-2 text-gray-80 hover:bg-gray-30 transition-colors disabled:opacity-50"
+                >
+                  {postInquiryConfirmMutation.isPending
+                    ? "처리중..."
+                    : "확인 처리"}
+                </button>
+                <button
+                  onClick={handleNotifyAssignees}
+                  disabled={postInquiryNotifyMutation.isPending}
+                  className="rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 transition-colors disabled:opacity-50"
+                >
+                  {postInquiryNotifyMutation.isPending
+                    ? "발송중..."
+                    : "알림 발송"}
+                </button>
+              </div>
+            )}
+          </div>
+          <div className="mt-4 flex flex-col w-full">
+            <AnswerList
+              comments={comments}
+              selectedCommentId={selectedCommentId}
+              onSelectComment={setSelectedCommentId}
             />
-          )}
-        </div>
+            {selectedComment && (
+              <AnswerItem
+                comment={selectedComment}
+                isOnlyComment={comments.length === 1}
+                currentUserId={currentUserId}
+              />
+            )}
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/constants/inquiryStates.ts
+++ b/src/constants/inquiryStates.ts
@@ -6,11 +6,11 @@ export type InquiryState =
 
 // 상태 매핑
 export const STATUS_MAPPING: Record<string, InquiryState> = {
-  OPEN: "BEFORE_CONFIRM",
+  UNCHECKED: "BEFORE_CONFIRM", // 서버 데이터 'UNCHECKED' 추가
   IN_PROGRESS: "IN_PROGRESS",
-  RESOLVED: "COMPLETED",
-  CLOSED: "COMPLETED",
-} as const;
+  COMPLETED: "COMPLETED", // 서버 데이터 'COMPLETED'로 변경
+  DEFERRED: "PENDING",
+};
 
 // 한글 상태명
 export const INQUIRY_STATE_LABELS: Record<InquiryState, string> = {

--- a/src/hooks/inquiry/useAnswerApi.ts
+++ b/src/hooks/inquiry/useAnswerApi.ts
@@ -1,0 +1,80 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  PostAnswerRequest,
+  PutAnswerRequest,
+} from "@/types/inquiry/answerApi.type";
+
+import {
+  deleteAnswer,
+  postAnswer,
+  postInquiryConfirm,
+  putAnswer,
+} from "@/apis/inquiry/answer/answerApi";
+
+export const useAnswerApi = (team_id?: number) => {
+  const queryClient = useQueryClient();
+
+  // 답변 작성
+  const postAnswerMutation = useMutation({
+    mutationFn: ({
+      inquiry_id,
+      data,
+    }: {
+      inquiry_id: number;
+      data: PostAnswerRequest;
+    }) => postAnswer(inquiry_id, data),
+    onSuccess: (_, variables) => {
+      if (team_id) {
+        queryClient.invalidateQueries({
+          queryKey: ["teamInquiry", team_id, variables.inquiry_id],
+        });
+      }
+    },
+  });
+
+  // 답변 수정
+  const putAnswerMutation = useMutation({
+    mutationFn: ({
+      answer_id,
+      data,
+    }: {
+      answer_id: number;
+      data: PutAnswerRequest;
+    }) => putAnswer(answer_id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["teamInquiry"],
+      });
+    },
+  });
+
+  // 답변 삭제
+  const deleteAnswerMutation = useMutation({
+    mutationFn: ({ answer_id }: { answer_id: number }) =>
+      deleteAnswer(answer_id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["teamInquiry"],
+      });
+    },
+  });
+
+  // 문의 확인 처리
+  const postInquiryConfirmMutation = useMutation({
+    mutationFn: ({ inquiry_id }: { inquiry_id: number }) =>
+      postInquiryConfirm(inquiry_id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["teamInquiry"],
+      });
+    },
+  });
+
+  return {
+    postAnswerMutation,
+    putAnswerMutation,
+    deleteAnswerMutation,
+    postInquiryConfirmMutation,
+  };
+};

--- a/src/hooks/inquiry/useAnswerApi.ts
+++ b/src/hooks/inquiry/useAnswerApi.ts
@@ -1,9 +1,12 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { useMyProfile } from "@/hooks/profile/useProfileApi";
+import { GlobalResponse } from "@/types/apiResponse.type";
 import {
   PostAnswerRequest,
   PutAnswerRequest,
 } from "@/types/inquiry/answerApi.type";
+import { InquiryData } from "@/types/inquiryTypes";
 
 import {
   deleteAnswer,
@@ -14,8 +17,9 @@ import {
 
 export const useAnswerApi = (team_id?: number) => {
   const queryClient = useQueryClient();
+  const { data: myProfileResponse } = useMyProfile();
+  const currentUserId = myProfileResponse?.result.id;
 
-  // 답변 작성
   const postAnswerMutation = useMutation({
     mutationFn: ({
       inquiry_id,
@@ -33,7 +37,6 @@ export const useAnswerApi = (team_id?: number) => {
     },
   });
 
-  // 답변 수정
   const putAnswerMutation = useMutation({
     mutationFn: ({
       answer_id,
@@ -43,31 +46,45 @@ export const useAnswerApi = (team_id?: number) => {
       data: PutAnswerRequest;
     }) => putAnswer(answer_id, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["teamInquiry"],
-      });
+      queryClient.invalidateQueries({ queryKey: ["teamInquiry"] });
     },
   });
 
-  // 답변 삭제
   const deleteAnswerMutation = useMutation({
     mutationFn: ({ answer_id }: { answer_id: number }) =>
       deleteAnswer(answer_id),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["teamInquiry"],
-      });
+      queryClient.invalidateQueries({ queryKey: ["teamInquiry"] });
     },
   });
 
-  // 문의 확인 처리
   const postInquiryConfirmMutation = useMutation({
     mutationFn: ({ inquiry_id }: { inquiry_id: number }) =>
       postInquiryConfirm(inquiry_id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["teamInquiry"],
-      });
+    onSuccess: (_, variables) => {
+      const { inquiry_id } = variables;
+      const queryKey = ["teamInquiry", team_id, inquiry_id];
+
+      // 캐시를 직접 수정하여 즉시 UI 업데이트
+      const previousData =
+        queryClient.getQueryData<GlobalResponse<InquiryData>>(queryKey);
+
+      if (previousData) {
+        const newData = {
+          ...previousData,
+          result: {
+            ...previousData.result,
+            assignees: previousData.result.assignees.map(assignee =>
+              assignee.user_id === currentUserId
+                ? { ...assignee, is_checked: true }
+                : assignee
+            ),
+            confirmed_assignees_count:
+              previousData.result.confirmed_assignees_count + 1,
+          },
+        };
+        queryClient.setQueryData(queryKey, newData);
+      }
     },
   });
 

--- a/src/hooks/inquiry/useInquiryApi.ts
+++ b/src/hooks/inquiry/useInquiryApi.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { GlobalResponse } from "@/types/apiResponse.type";
+import { GetInquiryDetailResponse } from "@/types/inquiry/inquiryDetailApi.type";
+
+import { getInquiryDetail } from "@/apis/inquiry/detail/inquiryDetailApi";
+
+/**
+ * @description 문의 상세 정보를 가져오는 useQuery 훅 (기존 버전과 호환)
+ * @param {number} team_id
+ * @param {number} inquiry_id
+ */
+export const useGetTeamInquiryDetail = (team_id: number, inquiry_id: number) =>
+  useQuery<GlobalResponse<GetInquiryDetailResponse>>({
+    queryKey: ["teamInquiry", team_id, inquiry_id],
+    queryFn: () => getInquiryDetail(team_id, inquiry_id),
+    enabled: !!team_id && !!inquiry_id,
+  });

--- a/src/hooks/inquiry/useInquiryManagementApi.ts
+++ b/src/hooks/inquiry/useInquiryManagementApi.ts
@@ -1,11 +1,46 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { PutInquiryAssigneeRequest } from "@/types/inquiry/inquiryManagementApi.type";
+import { GlobalResponse } from "@/types/apiResponse.type";
+import {
+  GetLastSentMailTimeResponse,
+  PutInquiryAssigneeRequest,
+  PutInquiryRequest,
+} from "@/types/inquiry/inquiryManagementApi.type";
 
 import {
+  deleteInquiry,
+  getLastSentMailTime,
   postInquiryNotify,
+  putInquiry,
   putInquiryAssignee,
 } from "@/apis/inquiry/detail/inquiryManagementApi";
+
+// 마지막 메일 전송 시간을 가져오는 훅 - 404 에러를 정상으로 처리
+export const useGetLastSentMailTime = (inquiry_id: number) => {
+  return useQuery({
+    queryKey: ["lastSentMailTime", inquiry_id],
+    queryFn: async () => {
+      try {
+        return await getLastSentMailTime(inquiry_id);
+      } catch (error: unknown) {
+        // any -> unknown
+        const err = error as { response?: { status?: number } };
+        if (err.response?.status === 404) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    enabled: !!inquiry_id,
+    retry: (failureCount, error: unknown) => {
+      const err = error as { response?: { status?: number } };
+      if (err.response?.status === 404) {
+        return false;
+      }
+      return failureCount < 3;
+    },
+  });
+};
 
 export const useInquiryManagementApi = () => {
   const queryClient = useQueryClient();
@@ -33,11 +68,55 @@ export const useInquiryManagementApi = () => {
   const postInquiryNotifyMutation = useMutation({
     mutationFn: ({ inquiry_id }: { inquiry_id: number }) =>
       postInquiryNotify(inquiry_id),
-    // 성공 시 특별한 처리가 필요하다면 onSuccess 추가 가능
+    // 성공 시, 캐시를 직접 수정하여 UI를 즉시 업데이트
+    onSuccess: (_, variables) => {
+      const queryKey = ["lastSentMailTime", variables.inquiry_id];
+
+      // lastSentMailTime 쿼리의 캐시 데이터를 현재 시간으로 즉시 업데이트
+      const newData: GlobalResponse<GetLastSentMailTimeResponse> = {
+        is_success: true,
+        code: "COMMON200",
+        message: "성공",
+        result: {
+          inquiryId: variables.inquiry_id,
+          lastSentTime: new Date().toISOString(),
+        },
+      };
+
+      queryClient.setQueryData(queryKey, newData);
+    },
+  });
+
+  // 문의글 삭제
+  const deleteInquiryMutation = useMutation({
+    mutationFn: ({ inquiry_id }: { inquiry_id: number }) =>
+      deleteInquiry(inquiry_id),
+    onSuccess: () => {
+      // 삭제 성공 시, 목록 데이터를 새로고침
+      queryClient.invalidateQueries({ queryKey: ["teamInquiryList"] });
+    },
+  });
+
+  // 문의글 수정
+  const putInquiryMutation = useMutation({
+    mutationFn: ({
+      inquiry_id,
+      data,
+    }: {
+      inquiry_id: number;
+      data: PutInquiryRequest;
+    }) => putInquiry(inquiry_id, data),
+    onSuccess: () => {
+      // 수정 성공 시, 해당 문의글 상세 정보 새로고침
+      // team_id를 알 수 없으므로, 모든 상세글 쿼리를 무효화
+      queryClient.invalidateQueries({ queryKey: ["teamInquiry"] });
+    },
   });
 
   return {
     putInquiryAssigneeMutation,
     postInquiryNotifyMutation,
+    deleteInquiryMutation,
+    putInquiryMutation,
   };
 };

--- a/src/hooks/inquiry/useInquiryManagementApi.ts
+++ b/src/hooks/inquiry/useInquiryManagementApi.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { PutInquiryAssigneeRequest } from "@/types/inquiry/inquiryManagementApi.type";
+
+import {
+  postInquiryNotify,
+  putInquiryAssignee,
+} from "@/apis/inquiry/detail/inquiryManagementApi";
+
+export const useInquiryManagementApi = () => {
+  const queryClient = useQueryClient();
+
+  // 담당자 수정
+  const putInquiryAssigneeMutation = useMutation({
+    mutationFn: ({
+      team_id,
+      inquiry_id,
+      data,
+    }: {
+      team_id: number;
+      inquiry_id: number;
+      data: PutInquiryAssigneeRequest;
+    }) => putInquiryAssignee(team_id, inquiry_id, data),
+    onSuccess: (_, variables) => {
+      // 문의 상세 정보 다시 불러오기
+      queryClient.invalidateQueries({
+        queryKey: ["teamInquiry", variables.team_id, variables.inquiry_id],
+      });
+    },
+  });
+
+  // 알림 메일 발송
+  const postInquiryNotifyMutation = useMutation({
+    mutationFn: ({ inquiry_id }: { inquiry_id: number }) =>
+      postInquiryNotify(inquiry_id),
+    // 성공 시 특별한 처리가 필요하다면 onSuccess 추가 가능
+  });
+
+  return {
+    putInquiryAssigneeMutation,
+    postInquiryNotifyMutation,
+  };
+};

--- a/src/hooks/inquiry/useInquiryManagementApi.ts
+++ b/src/hooks/inquiry/useInquiryManagementApi.ts
@@ -89,8 +89,13 @@ export const useInquiryManagementApi = () => {
 
   // 문의글 삭제
   const deleteInquiryMutation = useMutation({
-    mutationFn: ({ inquiry_id }: { inquiry_id: number }) =>
-      deleteInquiry(inquiry_id),
+    mutationFn: ({
+      team_id,
+      inquiry_id,
+    }: {
+      team_id: number;
+      inquiry_id: number;
+    }) => deleteInquiry(team_id, inquiry_id),
     onSuccess: () => {
       // 삭제 성공 시, 목록 데이터를 새로고침
       queryClient.invalidateQueries({ queryKey: ["teamInquiryList"] });

--- a/src/hooks/profile/useProfileApi.ts
+++ b/src/hooks/profile/useProfileApi.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getMyProfile } from "@/apis/profile/profileApi";
+import { useAuthStore } from "@/store/useAuthStore";
+
+export const useMyProfile = () => {
+  const isLogin = useAuthStore(state => state.isLogin);
+
+  return useQuery({
+    queryKey: ["myProfile"], // 쿼리 키
+    queryFn: getMyProfile, // API 호출 함수
+    enabled: isLogin, // 로그인이 되어 있을 때만 이 쿼리를 실행
+    staleTime: 1000 * 60 * 60, // 1시간 동안 데이터를 '신선함'으로 간주 (불필요한 API 호출 방지)
+  });
+};

--- a/src/hooks/scrap/useScrapApi.ts
+++ b/src/hooks/scrap/useScrapApi.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { deleteScrap, postScrap } from "@/apis/scrap/scrapApi";
+
+export const useScrapApi = (team_id?: number, inquiry_id?: number) => {
+  // team_id와 inquiry_id를 인자로 받습니다.
+  const queryClient = useQueryClient();
+
+  const postScrapMutation = useMutation({
+    mutationFn: ({ inquiry_id }: { inquiry_id: number }) =>
+      postScrap(inquiry_id),
+    onSuccess: () => {
+      if (team_id && inquiry_id) {
+        queryClient.invalidateQueries({
+          queryKey: ["teamInquiry", team_id, inquiry_id],
+        });
+      } else {
+        // ID가 없다면 넓은 범위로 무효화
+        queryClient.invalidateQueries({ queryKey: ["teamInquiry"] });
+      }
+      queryClient.invalidateQueries({ queryKey: ["scrap"] });
+    },
+  });
+
+  // deleteScrapMutation도 동일하게 수정
+  const deleteScrapMutation = useMutation({
+    mutationFn: ({ inquiry_id }: { inquiry_id: number }) =>
+      deleteScrap(inquiry_id),
+    onSuccess: () => {
+      if (team_id && inquiry_id) {
+        queryClient.invalidateQueries({
+          queryKey: ["teamInquiry", team_id, inquiry_id],
+        });
+      } else {
+        queryClient.invalidateQueries({ queryKey: ["teamInquiry"] });
+      }
+      queryClient.invalidateQueries({ queryKey: ["scrap"] });
+    },
+  });
+
+  return { postScrapMutation, deleteScrapMutation };
+};

--- a/src/hooks/useInquiryDetail.ts
+++ b/src/hooks/useInquiryDetail.ts
@@ -1,0 +1,305 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { AxiosError } from "axios";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { useAnswerApi } from "@/hooks/inquiry/useAnswerApi";
+import { useGetTeamInquiryDetail } from "@/hooks/inquiry/useInquiryApi";
+import {
+  useGetLastSentMailTime,
+  useInquiryManagementApi,
+} from "@/hooks/inquiry/useInquiryManagementApi";
+import { useMyProfile } from "@/hooks/profile/useProfileApi";
+import type { Comment, User } from "@/types/inquiryTypes";
+import type { ModalProps } from "@/types/modal";
+
+import { useInquiryModals } from "./useInquiryModals";
+
+const NOTIFICATION_COOLDOWN = 4 * 60 * 60 * 1000;
+
+export const useInquiryDetail = () => {
+  // 훅 호출
+  const navigate = useNavigate();
+  const { team_id, inquiry_id } = useParams<{
+    team_id: string;
+    inquiry_id: string;
+  }>();
+
+  const {
+    data: inquiryResponse,
+    isLoading,
+    isError,
+    error,
+  } = useGetTeamInquiryDetail(Number(team_id), Number(inquiry_id));
+  const { data: myProfileResponse } = useMyProfile();
+  const { postAnswerMutation, putAnswerMutation, postInquiryConfirmMutation } =
+    useAnswerApi(Number(team_id));
+  const {
+    deleteInquiryMutation,
+    postInquiryNotifyMutation,
+    putInquiryAssigneeMutation,
+  } = useInquiryManagementApi();
+  const {
+    data: lastSentTimeResponse,
+    isError: isMailTimeError,
+    error: mailTimeError,
+  } = useGetLastSentMailTime(Number(inquiry_id));
+
+  // 상태 관리
+  const [showEditor, setShowEditor] = useState(false);
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
+  const [draftContent, setDraftContent] = useState("");
+  const [editingComment, setEditingComment] = useState<Comment | null>(null);
+  const [notificationSent, setNotificationSent] = useState(false);
+  const [remainingTime, setRemainingTime] = useState("");
+  const [isAssigneeModalOpen, setIsAssigneeModalOpen] = useState(false);
+  const [selectedAssignees, setSelectedAssignees] = useState<User[]>([]);
+  const [modalProps, setModalProps] = useState<Omit<
+    ModalProps,
+    "isOpen" | "onClose"
+  > | null>(null);
+
+  // 데이터 정제
+  const currentUserId = myProfileResponse?.result.id;
+  const inquiryData = inquiryResponse?.result;
+
+  const myComment = useMemo(
+    () =>
+      inquiryData?.answers.answers.find(c => c.user?.user_id === currentUserId),
+    [inquiryData, currentUserId]
+  );
+
+  const tabsToDisplay = useMemo(() => {
+    if (!inquiryData) return [];
+    const answerers = inquiryData.answers.answers
+      .map(c => c.user)
+      .filter((user): user is NonNullable<typeof user> => !!user);
+    const uniqueAnswerers = Array.from(
+      new Map(answerers.map(a => [a.user_id, a])).values()
+    );
+    return uniqueAnswerers.map(a => ({
+      user_id: a.user_id,
+      username: a.username,
+      profile_image_url: a.profile_url,
+    }));
+  }, [inquiryData]);
+
+  const selectedComment = useMemo(() => {
+    if (!inquiryData || inquiryData.answers.answers.length === 0) return null;
+    const targetId = selectedUserId ?? tabsToDisplay[0]?.user_id;
+    return (
+      inquiryData.answers.answers.find(c => c.user?.user_id === targetId) ||
+      null
+    );
+  }, [selectedUserId, inquiryData, tabsToDisplay]);
+
+  useEffect(() => {
+    if (inquiryData && !selectedUserId) {
+      const firstAnswerer = inquiryData.answers.answers.find(c => c.user);
+      if (firstAnswerer) {
+        setSelectedUserId(firstAnswerer.user.user_id);
+      }
+    }
+  }, [inquiryData, selectedUserId]);
+
+  useEffect(() => {
+    if (
+      isMailTimeError &&
+      mailTimeError instanceof AxiosError &&
+      mailTimeError.response?.status === 404
+    ) {
+      setNotificationSent(false);
+      return;
+    }
+    const lastSentTimeData = lastSentTimeResponse?.result.lastSentTime;
+    if (!lastSentTimeData) {
+      setNotificationSent(false);
+      return;
+    }
+    const lastNotifiedTime = new Date(lastSentTimeData).getTime();
+    const intervalId = setInterval(() => {
+      const now = new Date().getTime();
+      const timeDiff = now - lastNotifiedTime;
+      if (timeDiff >= NOTIFICATION_COOLDOWN) {
+        clearInterval(intervalId);
+        // 0.5초(500ms) 지연 후 버튼을 활성화합니다.
+        setTimeout(() => {
+          setNotificationSent(false);
+          setRemainingTime("");
+        }, 500);
+      } else {
+        setNotificationSent(true);
+        const remaining = NOTIFICATION_COOLDOWN - timeDiff;
+        const hours = String(Math.floor(remaining / (1000 * 60 * 60))).padStart(
+          2,
+          "0"
+        );
+        const minutes = String(
+          Math.floor((remaining % (1000 * 60 * 60)) / (1000 * 60))
+        ).padStart(2, "0");
+        const seconds = String(
+          Math.floor((remaining % (1000 * 60)) / 1000)
+        ).padStart(2, "0");
+        setRemainingTime(`${hours}:${minutes}:${seconds}`);
+      }
+    }, 1000);
+    return () => clearInterval(intervalId);
+  }, [lastSentTimeResponse, isMailTimeError, mailTimeError]);
+
+  // 실제 API를 호출하는 콜백 함수들
+  const onConfirmInquiry = async () => {
+    try {
+      await postInquiryConfirmMutation.mutateAsync({
+        inquiry_id: Number(inquiry_id),
+      });
+    } catch (error) {
+      console.error("문의 확인 처리 실패:", error);
+    }
+  };
+
+  const onSubmitAnswer = async () => {
+    if (draftContent.trim().length === 0) return;
+    try {
+      if (editingComment) {
+        await putAnswerMutation.mutateAsync({
+          answer_id: editingComment.comment_id,
+          data: { content: draftContent, file_ids: null },
+        });
+        setSelectedUserId(editingComment.user.user_id);
+      } else {
+        await postAnswerMutation.mutateAsync({
+          inquiry_id: Number(inquiry_id),
+          data: { content: draftContent, file_ids: null },
+        });
+        if (currentUserId) setSelectedUserId(currentUserId);
+      }
+      setShowEditor(false);
+    } catch (error) {
+      console.error("답변 처리 실패:", error);
+    }
+  };
+
+  const onSendNotification = async () => {
+    try {
+      await postInquiryNotifyMutation.mutateAsync({
+        inquiry_id: Number(inquiry_id),
+      });
+    } catch (error) {
+      console.error("알림 발송 실패:", error);
+    }
+  };
+
+  const onDeletePost = async () => {
+    try {
+      await deleteInquiryMutation.mutateAsync({
+        inquiry_id: Number(inquiry_id),
+      });
+      navigate(`/teams/${team_id}`);
+    } catch (error) {
+      console.error("문의글 삭제 실패:", error);
+    }
+  };
+
+  // 모달을 여는 함수들을 생성
+  const modals = useInquiryModals({
+    setModalProps,
+    callbacks: {
+      onConfirmInquiry,
+      onSubmitAnswer,
+      onSendNotification,
+      onDeletePost,
+    },
+  });
+
+  // 핸들러 함수
+  const handleOpenAssigneeModal = () => {
+    const initialAssignees =
+      inquiryData?.assignees.map(a => ({
+        id: a.user_id,
+        user_name: a.user_name,
+        profile_image_url: a.profile_image_url || "",
+      })) || [];
+    setSelectedAssignees(initialAssignees);
+    setIsAssigneeModalOpen(true);
+  };
+
+  const handleCloseAssigneeModal = () => {
+    setIsAssigneeModalOpen(false);
+  };
+
+  const handleUpdateAssignees = async () => {
+    const assigneeIds = selectedAssignees.map(a => a.id);
+    try {
+      await putInquiryAssigneeMutation.mutateAsync({
+        team_id: Number(team_id),
+        inquiry_id: Number(inquiry_id),
+        data: { assignee_ids: assigneeIds },
+      });
+      handleCloseAssigneeModal();
+    } catch (error) {
+      console.error("담당자 수정 실패:", error);
+    }
+  };
+
+  const handleStartAnswer = (commentToEdit?: Comment) => {
+    if (commentToEdit) {
+      setEditingComment(commentToEdit);
+      setDraftContent(commentToEdit.content);
+    } else {
+      setEditingComment(null);
+      setDraftContent(myComment?.content || "");
+    }
+    setShowEditor(true);
+  };
+
+  const handleSelectTab = (userId: number) => {
+    setSelectedUserId(userId);
+    setShowEditor(false);
+  };
+
+  const onEditorSubmit = (content: string) => {
+    if (content.trim().length === 0) {
+      alert("답변 내용을 입력해주세요.");
+      return;
+    }
+    setDraftContent(content);
+    modals.openSubmitAnswerModal(!!editingComment);
+  };
+
+  const handleConfirm = () => modals.openConfirmInquiryModal();
+  const handleDeleteInquiry = () => modals.openDeletePostModal();
+  const handleNotify = () => modals.openSendNotificationModal();
+
+  return {
+    isLoading,
+    isError,
+    error,
+    inquiryData,
+    currentUserId,
+    showEditor,
+    tabsToDisplay,
+    selectedUserId,
+    selectedComment,
+    myComment,
+    draftContent,
+    setDraftContent,
+    editingComment,
+    notificationSent,
+    remainingTime,
+    isAssigneeModalOpen,
+    selectedAssignees,
+    setSelectedAssignees,
+    handleOpenAssigneeModal,
+    handleCloseAssigneeModal,
+    handleUpdateAssignees,
+    putInquiryAssigneeMutation,
+    modalProps,
+    closeModal: () => setModalProps(null),
+    handleStartAnswer,
+    handleSelectTab,
+    onEditorSubmit,
+    handleConfirm,
+    handleDeleteInquiry,
+    handleNotify,
+  };
+};

--- a/src/hooks/useInquiryDetail.ts
+++ b/src/hooks/useInquiryDetail.ts
@@ -50,6 +50,7 @@ export const useInquiryDetail = () => {
   const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
   const [draftContent, setDraftContent] = useState("");
   const [editingComment, setEditingComment] = useState<Comment | null>(null);
+  const [isWritingAnswer, setIsWritingAnswer] = useState(false); // 답변 작성 중인지 추적
   const [notificationSent, setNotificationSent] = useState(false);
   const [remainingTime, setRemainingTime] = useState("");
   const [isAssigneeModalOpen, setIsAssigneeModalOpen] = useState(false);
@@ -69,20 +70,50 @@ export const useInquiryDetail = () => {
     [inquiryData, currentUserId]
   );
 
+  // 탭 목록에 현재 사용자 포함 (답변 작성 중일 때)
   const tabsToDisplay = useMemo(() => {
-    if (!inquiryData) return [];
+    if (!inquiryData || !currentUserId) return [];
+
     const answerers = inquiryData.answers.answers
       .map(c => c.user)
       .filter((user): user is NonNullable<typeof user> => !!user);
+
     const uniqueAnswerers = Array.from(
       new Map(answerers.map(a => [a.user_id, a])).values()
     );
+
+    // 답변 작성 중이거나 작성한 적이 있으면서 내 답변이 없는 경우, 내 정보를 탭에 추가
+    if (
+      (showEditor || isWritingAnswer) &&
+      !myComment &&
+      myProfileResponse?.result
+    ) {
+      const myInfo = {
+        user_id: currentUserId,
+        username: myProfileResponse.result.name,
+        profile_url: myProfileResponse.result.profile_image_url || undefined,
+      };
+
+      // 중복 제거를 위해 기존 답변자 중에 내가 없을 때만 추가
+      const hasMyTab = uniqueAnswerers.some(a => a.user_id === currentUserId);
+      if (!hasMyTab) {
+        uniqueAnswerers.push(myInfo);
+      }
+    }
+
     return uniqueAnswerers.map(a => ({
       user_id: a.user_id,
       username: a.username,
       profile_image_url: a.profile_url,
     }));
-  }, [inquiryData]);
+  }, [
+    inquiryData,
+    currentUserId,
+    showEditor,
+    isWritingAnswer,
+    myComment,
+    myProfileResponse,
+  ]);
 
   const selectedComment = useMemo(() => {
     if (!inquiryData || inquiryData.answers.answers.length === 0) return null;
@@ -174,6 +205,7 @@ export const useInquiryDetail = () => {
         if (currentUserId) setSelectedUserId(currentUserId);
       }
       setShowEditor(false);
+      setIsWritingAnswer(false); // 답변 제출 완료
     } catch (error) {
       console.error("답변 처리 실패:", error);
     }
@@ -251,11 +283,28 @@ export const useInquiryDetail = () => {
       setDraftContent(myComment?.content || "");
     }
     setShowEditor(true);
+    setIsWritingAnswer(true); // 답변 작성 시작
+    // 답변 작성을 시작할 때 내 탭으로 선택
+    if (currentUserId) {
+      setSelectedUserId(currentUserId);
+    }
   };
 
   const handleSelectTab = (userId: number) => {
     setSelectedUserId(userId);
-    setShowEditor(false);
+    // 내 탭을 클릭했을 때만 에디터 표시
+    if (userId === currentUserId && (showEditor || myComment)) {
+      if (!myComment) {
+        // 내 답변이 없고 답변 작성 중인 경우 에디터 표시
+        setShowEditor(true);
+      } else {
+        // 내 답변이 있는 경우 에디터 숨김
+        setShowEditor(false);
+      }
+    } else {
+      // 다른 사람의 탭을 클릭한 경우 에디터 숨김
+      setShowEditor(false);
+    }
   };
 
   const onEditorSubmit = (content: string) => {
@@ -285,6 +334,7 @@ export const useInquiryDetail = () => {
     draftContent,
     setDraftContent,
     editingComment,
+    isWritingAnswer,
     notificationSent,
     remainingTime,
     isAssigneeModalOpen,

--- a/src/hooks/useInquiryDetail.ts
+++ b/src/hooks/useInquiryDetail.ts
@@ -192,6 +192,7 @@ export const useInquiryDetail = () => {
   const onDeletePost = async () => {
     try {
       await deleteInquiryMutation.mutateAsync({
+        team_id: Number(team_id),
         inquiry_id: Number(inquiry_id),
       });
       navigate(`/teams/${team_id}`);

--- a/src/hooks/useInquiryModals.ts
+++ b/src/hooks/useInquiryModals.ts
@@ -1,0 +1,105 @@
+import type { ModalProps } from "@/types/modal";
+
+// 모달 콜백 함수 타입
+interface ModalCallbacks {
+  onConfirmInquiry: () => void;
+  onSubmitAnswer: () => void;
+  onSendNotification: () => void;
+  onDeletePost: () => void;
+}
+
+interface UseInquiryModalsProps {
+  setModalProps: React.Dispatch<
+    React.SetStateAction<Omit<ModalProps, "isOpen" | "onClose"> | null>
+  >;
+  callbacks: ModalCallbacks;
+}
+
+export const useInquiryModals = ({
+  setModalProps,
+  callbacks,
+}: UseInquiryModalsProps) => {
+  const closeModal = () => setModalProps(null);
+
+  const openConfirmInquiryModal = () => {
+    setModalProps({
+      title: "해당 문의를 확인 처리할까요?",
+      description:
+        "확인 처리는 취소되지 않으며,\n추후 언제든지 답변을 작성하실 수 있습니다.",
+      buttons: [
+        { type: "white", label: "취소", onClick: closeModal },
+        {
+          type: "blue",
+          label: "확인",
+          onClick: () => {
+            callbacks.onConfirmInquiry();
+            closeModal();
+          },
+        },
+      ],
+    });
+  };
+
+  const openSubmitAnswerModal = (isEditing: boolean) => {
+    setModalProps({
+      title: isEditing ? "답변을 수정할까요?" : "답변을 등록할까요?",
+      description: isEditing
+        ? undefined
+        : "답변 등록 시 해당 문의는 자동으로 확인 처리되며,\n마지막 답변은 삭제되지 않습니다.",
+      buttons: [
+        { type: "white", label: "취소", onClick: closeModal },
+        {
+          type: "blue",
+          label: isEditing ? "수정하기" : "답변 등록",
+          onClick: () => {
+            callbacks.onSubmitAnswer();
+            closeModal();
+          },
+        },
+      ],
+    });
+  };
+
+  const openSendNotificationModal = () => {
+    setModalProps({
+      title: "메일을 발송하시겠습니까?",
+      description: "메일 전송 후 4시간후에 다시 메일을\n발송하실 수 있습니다.",
+      buttons: [
+        { type: "gray", label: "뒤로가기", onClick: closeModal },
+        {
+          type: "blue",
+          label: "메일 발송하기",
+          onClick: () => {
+            callbacks.onSendNotification();
+            closeModal();
+          },
+        },
+      ],
+    });
+  };
+
+  const openDeletePostModal = () => {
+    setModalProps({
+      title: "해당 게시글을 삭제하시겠습니까?",
+      description: "관리자 권한으로 게시글을 삭제 할 시\n복구 할 수 없습니다.",
+      buttons: [
+        { type: "gray", label: "취소", onClick: closeModal },
+        {
+          type: "red",
+          label: "게시글 삭제",
+          onClick: () => {
+            callbacks.onDeletePost();
+            closeModal();
+          },
+        },
+      ],
+    });
+  };
+
+  return {
+    openConfirmInquiryModal,
+    openSubmitAnswerModal,
+    openSendNotificationModal,
+    openDeletePostModal,
+  };
+};

--- a/src/hooks/useInquiryState.ts
+++ b/src/hooks/useInquiryState.ts
@@ -25,7 +25,7 @@ export const useInquiryState = (
 
   // 기본 권한 설정
   const permissions = USER_ROLE_PERMISSIONS[userRole];
-  const isWriter = inquiry.writer.user_id === currentUserId;
+  const isWriter = inquiry.author.user_id === currentUserId;
   const isAdmin = userRole === "admin";
 
   // 상태 매핑 및 계산
@@ -41,7 +41,7 @@ export const useInquiryState = (
   // 등록 보류 상태 확인 - API 데이터 기준으로 단순화
   const confirmedCount = inquiry.confirmed_assignees_count;
   const totalAssignees = inquiry.assignees?.length || 0;
-  const answersCount = inquiry.comment_count;
+  const answersCount = inquiry.answers.count;
   const isPendingState =
     confirmedCount === totalAssignees &&
     totalAssignees > 0 &&

--- a/src/hooks/useInquiryState.ts
+++ b/src/hooks/useInquiryState.ts
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import {
   INQUIRY_STATE_LABELS,
   INQUIRY_STATE_STYLES,
@@ -14,69 +12,41 @@ export const useInquiryState = (
   userRole: UserRole,
   currentUserId?: number
 ) => {
-  // UI 상태 관리
-  const [isAssigneeEditMode, setIsAssigneeEditMode] = useState(false);
-  const [notificationSent, setNotificationSent] = useState(false);
-
-  // API에서 제공하는 권한 사용 (우선순위)
-  const canEdit = inquiry.can_edit;
-  const canAnswer = inquiry.can_answer;
-  const canSendNotification = inquiry.can_notify;
-
-  // 기본 권한 설정
-  const permissions = USER_ROLE_PERMISSIONS[userRole];
+  const permissions =
+    USER_ROLE_PERMISSIONS[userRole] || USER_ROLE_PERMISSIONS["default"];
   const isWriter = inquiry.author.user_id === currentUserId;
   const isAdmin = userRole === "admin";
 
-  // 상태 매핑 및 계산
-  const mappedState = (STATUS_MAPPING[inquiry.inquiry_state] ||
+  const initialMappedState = (STATUS_MAPPING[inquiry.status] ||
     "BEFORE_CONFIRM") as InquiryState;
-  const stateLabel = INQUIRY_STATE_LABELS[mappedState];
-  const statusConfig = INQUIRY_STATE_STYLES[stateLabel] || {
+
+  const confirmedCount = inquiry.confirmed_assignees_count;
+  const totalAssignees = inquiry.assignees?.length || 0;
+  const answersCount = inquiry.answers.count;
+
+  // 최종 상태 라벨 계산
+  let finalStateLabel = INQUIRY_STATE_LABELS[initialMappedState];
+  if (initialMappedState === "BEFORE_CONFIRM" && totalAssignees > 0) {
+    if (confirmedCount === totalAssignees) {
+      finalStateLabel = answersCount > 0 ? "답변 완료" : "등록 보류";
+    } else if (confirmedCount > 0) {
+      finalStateLabel = "확인 중";
+    }
+  }
+
+  const finalStatusConfig = INQUIRY_STATE_STYLES[finalStateLabel] || {
     bg: "bg-gray-200",
     text: "text-gray-600",
     dot: "bg-gray-400",
   };
 
-  // 등록 보류 상태 확인 - API 데이터 기준으로 단순화
-  const confirmedCount = inquiry.confirmed_assignees_count;
-  const totalAssignees = inquiry.assignees?.length || 0;
-  const answersCount = inquiry.answers.count;
-  const isPendingState =
-    confirmedCount === totalAssignees &&
-    totalAssignees > 0 &&
-    answersCount === 0;
-
-  // 실제 표시될 상태
-  const finalStateLabel = isPendingState ? "등록 보류" : stateLabel;
-  const finalStatusConfig =
-    INQUIRY_STATE_STYLES[finalStateLabel] || statusConfig;
-
-  // 남은 시간 (UI용 더미 데이터)
-  const remainingTime = notificationSent ? "(3:59:59)" : "";
-
   return {
-    // UI 상태
-    isAssigneeEditMode,
-    setIsAssigneeEditMode,
-    notificationSent,
-    setNotificationSent,
-    canSendNotification,
-    remainingTime,
-
-    // API 권한
-    canEdit,
-    canAnswer,
-
-    // 권한
     permissions,
     isWriter,
     isAdmin,
-
-    // 상태 정보
     finalStateLabel,
     finalStatusConfig,
-    isPendingState,
     answersCount,
+    canSendNotification: inquiry.can_notify,
   };
 };

--- a/src/pages/inquiryDetail/InquiryDetailPage.tsx
+++ b/src/pages/inquiryDetail/InquiryDetailPage.tsx
@@ -1,39 +1,51 @@
-// src/pages/inquiryDetail/InquiryDetailPage.tsx
-import { useParams } from "react-router-dom";
-
 import AdditionalInquirySection from "@/components/AdditionalInquiry/AdditionalInquirySection";
+import Modal from "@/components/common/Modal";
 import AnswerSection from "@/components/inquiry/detail/answer/AnswerSection";
 import Header from "@/components/inquiry/detail/Header";
 import InquiryCard from "@/components/inquiry/detail/InquiryCard";
-import { useGetTeamInquiryDetail } from "@/hooks/inquiry/useInquiryApi";
+import { useInquiryDetail } from "@/hooks/useInquiryDetail";
+import type { UserRole } from "@/types/inquiryTypes";
 import { mockInquiryResponse } from "@/mocks/mockInquiryResponse";
 
 const InquiryDetailPage = () => {
-  const { team_id, inquiry_id } = useParams<{
-    team_id: string;
-    inquiry_id: string;
-  }>();
-
+  // 새로 만든 훅을 호출하여 모든 로직과 상태를 가져옴
   const {
-    data: inquiryResponse,
     isLoading,
     isError,
-    error,
-  } = useGetTeamInquiryDetail(Number(team_id), Number(inquiry_id));
+    inquiryData,
+    currentUserId,
+    showEditor,
+    tabsToDisplay,
+    selectedUserId,
+    selectedComment,
+    myComment,
+    draftContent,
+    setDraftContent,
+    editingComment,
+    notificationSent,
+    remainingTime,
+    handleStartAnswer,
+    handleSelectTab,
+    onEditorSubmit,
+    handleConfirm,
+    handleDeleteInquiry,
+    handleNotify,
+    modalProps,
+    closeModal,
+  } = useInquiryDetail();
 
-  // 로딩 및 에러 상태에서 사용할 기본 팀 정보
+  // 조건부 렌더링
   const defaultTeamInfo = {
     group_name: " ",
     division_name: " ",
     team_name: "문의 상세 정보",
   };
 
-  // 로딩 상태
   if (isLoading) {
     return (
       <div className="min-h-screen">
         <div className="mx-auto w-full">
-          <Header teamInfo={defaultTeamInfo} />
+          <Header teamInfo={defaultTeamInfo} onDelete={handleDeleteInquiry} />
           <div className="mt-8 rounded-2xl bg-white p-16 text-center">
             <div className="flex flex-col items-center gap-4">
               <div className="h-8 w-8 animate-spin rounded-full border-4 border-main border-t-transparent"></div>
@@ -47,15 +59,11 @@ const InquiryDetailPage = () => {
     );
   }
 
-  // 에러 상태
-  if (isError || !inquiryResponse?.result) {
-    if (isError) {
-      console.error("문의 상세 정보 로딩 실패:", error);
-    }
+  if (isError || !inquiryData) {
     return (
       <div className="min-h-screen">
         <div className="mx-auto w-full">
-          <Header teamInfo={defaultTeamInfo} />
+          <Header teamInfo={defaultTeamInfo} onDelete={handleDeleteInquiry} />
           <div className="mt-8 rounded-2xl bg-white p-16 text-center">
             <div className="flex flex-col items-center gap-4">
               <div className="rounded-full bg-red-100 p-4">
@@ -95,47 +103,65 @@ const InquiryDetailPage = () => {
     );
   }
 
-  // 데이터 로딩 성공 후
-  const inquiry = inquiryResponse.result;
-
-  // Header에 전달할 팀 정보 객체 생성
+  // 최종 렌더링
   const teamInfoForHeader = {
-    group_name: inquiry.group.groupName,
-    division_name: inquiry.division.divisionName,
-    team_name: inquiry.team.teamName,
+    group_name: inquiryData.group.group_name,
+    division_name: inquiryData.division.division_name,
+    team_name: inquiryData.team.team_name,
   };
 
-  // 권한 확인 - 기존 mock 데이터 구조 사용
-  const isAdmin = inquiry.test_user_role === "admin";
-  const currentUserId = inquiry.test_current_user_id;
+  const userRole = (inquiryData.role?.toLowerCase() || "default") as UserRole;
+  const isAdmin = userRole === "admin";
 
   return (
     <div className="min-h-screen bg-gray-5">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-14 px-6 py-8">
         <div className="flex flex-col gap-10">
-          {/* 헤더 */}
-          <Header isAdmin={isAdmin} teamInfo={teamInfoForHeader} />
-
-          {/* 문의글 카드 */}
+          <Header
+            isAdmin={isAdmin}
+            teamInfo={teamInfoForHeader}
+            onDelete={handleDeleteInquiry}
+          />
           <InquiryCard
-            inquiry={inquiry}
-            userRole={inquiry.test_user_role}
+            inquiry={inquiryData}
+            userRole={userRole}
             currentUserId={currentUserId}
+            handleStartAnswer={handleStartAnswer}
+            onConfirm={handleConfirm}
+            handleDeleteInquiry={handleDeleteInquiry}
+            handleNotify={handleNotify}
+            notificationSent={notificationSent}
+            remainingTime={remainingTime}
+            showEditor={showEditor}
+            myComment={myComment}
           />
         </div>
-
-        {/* 답변 섹션 */}
         <AnswerSection
-          inquiry_id={inquiry.inquiry_id}
-          team_id={Number(team_id)}
-          comments={inquiry.answers.answers}
+          inquiry={inquiryData}
           currentUserId={currentUserId}
-          canAnswer={inquiry.can_answer || isAdmin}
+          showEditor={showEditor}
+          tabsToDisplay={tabsToDisplay}
+          selectedUserId={selectedUserId}
+          selectedComment={selectedComment}
+          draftContent={draftContent}
+          setDraftContent={setDraftContent}
+          handleStartAnswer={handleStartAnswer}
+          handleSelectTab={handleSelectTab}
+          onEditorSubmit={onEditorSubmit}
+          editingComment={editingComment}
+          onDeleteAnswer={handleDeleteInquiry}
         />
-
-        {/* 추가문의 섹션 */}
         <AdditionalInquirySection inquiry={mockInquiryResponse} />
       </div>
+      {modalProps && (
+        <Modal
+          isOpen={true}
+          onClose={closeModal}
+          title={modalProps.title}
+          description={modalProps.description}
+          buttons={modalProps.buttons}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/inquiryDetail/InquiryDetailPage.tsx
+++ b/src/pages/inquiryDetail/InquiryDetailPage.tsx
@@ -1,58 +1,139 @@
+// src/pages/inquiryDetail/InquiryDetailPage.tsx
 import { useParams } from "react-router-dom";
 
 import AdditionalInquirySection from "@/components/AdditionalInquiry/AdditionalInquirySection";
 import AnswerSection from "@/components/inquiry/detail/answer/AnswerSection";
 import Header from "@/components/inquiry/detail/Header";
 import InquiryCard from "@/components/inquiry/detail/InquiryCard";
-import { InquiryData } from "@/types/inquiryTypes";
-import { mockInquiryDetailResponse } from "@/mocks/mockInquiryDetailResponse";
+import { useGetTeamInquiryDetail } from "@/hooks/inquiry/useInquiryApi";
 import { mockInquiryResponse } from "@/mocks/mockInquiryResponse";
 
 const InquiryDetailPage = () => {
-  const { id } = useParams<{ id: string }>();
+  const { team_id, inquiry_id } = useParams<{
+    team_id: string;
+    inquiry_id: string;
+  }>();
 
-  // mockInquiryDetailResponse에서 해당 inquiry 찾기
-  const inquiry = mockInquiryDetailResponse.inquiries.find(
-    item => item.inquiry_id === Number(id)
-  ) as InquiryData | undefined;
+  const {
+    data: inquiryResponse,
+    isLoading,
+    isError,
+    error,
+  } = useGetTeamInquiryDetail(Number(team_id), Number(inquiry_id));
 
-  if (!inquiry) {
+  // 로딩 및 에러 상태에서 사용할 기본 팀 정보
+  const defaultTeamInfo = {
+    group_name: " ",
+    division_name: " ",
+    team_name: "문의 상세 정보",
+  };
+
+  // 로딩 상태
+  if (isLoading) {
     return (
       <div className="min-h-screen">
         <div className="mx-auto w-full">
-          <Header />
+          <Header teamInfo={defaultTeamInfo} />
           <div className="mt-8 rounded-2xl bg-white p-16 text-center">
-            <h2 className="text-xl text-gray-80">문의를 찾을 수 없습니다.</h2>
+            <div className="flex flex-col items-center gap-4">
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-main border-t-transparent"></div>
+              <h2 className="text-xl text-gray-80">
+                데이터를 불러오는 중입니다...
+              </h2>
+            </div>
           </div>
         </div>
       </div>
     );
   }
 
-  // 각 문의별 테스트 시나리오의 권한과 사용자 ID 사용
-  const userRole = inquiry.test_user_role;
+  // 에러 상태
+  if (isError || !inquiryResponse?.result) {
+    if (isError) {
+      console.error("문의 상세 정보 로딩 실패:", error);
+    }
+    return (
+      <div className="min-h-screen">
+        <div className="mx-auto w-full">
+          <Header teamInfo={defaultTeamInfo} />
+          <div className="mt-8 rounded-2xl bg-white p-16 text-center">
+            <div className="flex flex-col items-center gap-4">
+              <div className="rounded-full bg-red-100 p-4">
+                <svg
+                  className="h-8 w-8 text-red-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+              </div>
+              <div>
+                <h2 className="text-xl font-semibold text-gray-80 mb-2">
+                  문의를 찾을 수 없습니다
+                </h2>
+                <p className="text-gray-60">
+                  요청하신 문의글을 불러올 수 없습니다. 잠시 후 다시
+                  시도해주세요.
+                </p>
+              </div>
+              <button
+                onClick={() => window.location.reload()}
+                className="mt-4 rounded-lg bg-main px-4 py-2 text-white hover:bg-main/90 transition-colors"
+              >
+                다시 시도
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 데이터 로딩 성공 후
+  const inquiry = inquiryResponse.result;
+
+  // Header에 전달할 팀 정보 객체 생성
+  const teamInfoForHeader = {
+    group_name: inquiry.group.groupName,
+    division_name: inquiry.division.divisionName,
+    team_name: inquiry.team.teamName,
+  };
+
+  // 권한 확인 - 기존 mock 데이터 구조 사용
+  const isAdmin = inquiry.test_user_role === "admin";
   const currentUserId = inquiry.test_current_user_id;
 
   return (
-    <div className="min-h-screen">
-      <div className="mx-auto flex w-full flex-col gap-[56px]">
+    <div className="min-h-screen bg-gray-5">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-14 px-6 py-8">
         <div className="flex flex-col gap-10">
           {/* 헤더 */}
-          <Header isAdmin={userRole === "admin"} />
+          <Header isAdmin={isAdmin} teamInfo={teamInfoForHeader} />
 
-          {/* 문의글 카드 - 자동 권한 설정 */}
+          {/* 문의글 카드 */}
           <InquiryCard
             inquiry={inquiry}
-            userRole={userRole}
+            userRole={inquiry.test_user_role}
             currentUserId={currentUserId}
           />
         </div>
-        {/* 답변 섹션 카드*/}
+
+        {/* 답변 섹션 */}
         <AnswerSection
-          comments={inquiry.comments}
+          inquiry_id={inquiry.inquiry_id}
+          team_id={Number(team_id)}
+          comments={inquiry.answers.answers}
           currentUserId={currentUserId}
+          canAnswer={inquiry.can_answer || isAdmin}
         />
 
+        {/* 추가문의 섹션 */}
         <AdditionalInquirySection inquiry={mockInquiryResponse} />
       </div>
     </div>

--- a/src/pages/inquiryDetail/InquiryDetailPage.tsx
+++ b/src/pages/inquiryDetail/InquiryDetailPage.tsx
@@ -22,6 +22,7 @@ const InquiryDetailPage = () => {
     draftContent,
     setDraftContent,
     editingComment,
+    isWritingAnswer,
     notificationSent,
     remainingTime,
     handleStartAnswer,
@@ -149,6 +150,7 @@ const InquiryDetailPage = () => {
           handleSelectTab={handleSelectTab}
           onEditorSubmit={onEditorSubmit}
           editingComment={editingComment}
+          isWritingAnswer={isWritingAnswer}
           onDeleteAnswer={handleDeleteInquiry}
         />
         <AdditionalInquirySection inquiry={mockInquiryResponse} />

--- a/src/types/inquiry/answerApi.type.ts
+++ b/src/types/inquiry/answerApi.type.ts
@@ -1,0 +1,34 @@
+/**
+ * POST /api/inquiries/{inquiry_id}/answers
+ */
+export interface PostAnswerRequest {
+  content: string;
+  file_ids?: number[] | null;
+}
+
+export interface PostAnswerResponse {
+  answer_id: number;
+  status: "PUBLISHED";
+  created_at: string;
+}
+
+/**
+ * PUT /api/answers/{answer_id}
+ */
+export interface PutAnswerRequest {
+  content: string;
+  file_ids?: number[] | null;
+}
+
+export interface PutAnswerResponse {
+  answer_id: number;
+  updated_at: string;
+}
+
+/**
+ * DELETE /api/answers/{answer_id}
+ */
+export interface DeleteAnswerResponse {
+  message: string;
+  deleted_at: string;
+}

--- a/src/types/inquiry/inquiryDetailApi.type.ts
+++ b/src/types/inquiry/inquiryDetailApi.type.ts
@@ -1,0 +1,5 @@
+export type {
+  Comment,
+  FollowUp,
+  InquiryData as GetInquiryDetailResponse,
+} from "@/types/inquiryTypes";

--- a/src/types/inquiry/inquiryManagementApi.type.ts
+++ b/src/types/inquiry/inquiryManagementApi.type.ts
@@ -1,0 +1,6 @@
+/**
+ * PUT /api/teams/{team_id}/inquiries/{inquiry_id}/change-assignee
+ */
+export interface PutInquiryAssigneeRequest {
+  assignee_ids: number[];
+}

--- a/src/types/inquiry/inquiryManagementApi.type.ts
+++ b/src/types/inquiry/inquiryManagementApi.type.ts
@@ -4,3 +4,34 @@
 export interface PutInquiryAssigneeRequest {
   assignee_ids: number[];
 }
+
+/**
+ * DELETE /api/inquiries/{inquiry_id} (문의글 삭제)
+ */
+export interface DeleteInquiryResponse {
+  status: string;
+  deleted_at: string;
+}
+
+/**
+ * GET /api/inquiries/{inquiry_id}/mails/last-sent-time (마지막 메일 전송시간 조회)
+ */
+export interface GetLastSentMailTimeResponse {
+  inquiryId: number;
+  lastSentTime: string;
+}
+
+/**
+ * PUT /api/inquiries/{inquiry_id} (문의글 수정)
+ */
+export interface PutInquiryRequest {
+  title: string;
+  content: string;
+  assignee_ids: number[];
+  observer_ids: number[]; // API 명세서에는 reference_ids
+}
+
+export interface PutInquiryResponse {
+  inquiry_id: number;
+  updated_at: string;
+}

--- a/src/types/inquiryTypes.ts
+++ b/src/types/inquiryTypes.ts
@@ -243,6 +243,7 @@ export interface AnswerSectionProps {
   onEditorSubmit: (content: string) => void;
   onDeleteAnswer: (answerId: number) => void;
   editingComment: Comment | null;
+  isWritingAnswer: boolean;
 }
 
 // NotificationButton Props 타입

--- a/src/types/inquiryTypes.ts
+++ b/src/types/inquiryTypes.ts
@@ -3,9 +3,10 @@ export type UserRole = "default" | "assignee" | "writer" | "admin";
 // 답변 타입
 export interface Comment {
   comment_id: number;
-  writer: {
+  // [수정] 'writer'를 'author'로, 'name'을 'username'으로 통일
+  author: {
     user_id: number;
-    name: string;
+    username: string;
     profile_image_url?: string;
     team_name?: string;
   };
@@ -19,9 +20,9 @@ export interface FollowUp {
   follow_up_id: number;
   content: string;
   created_at: string;
-  writer: {
+  author: {
     user_id: number;
-    name: string;
+    username: string;
     profile_image_url?: string;
   };
   comments: Comment[];
@@ -31,17 +32,22 @@ export interface FollowUp {
 export interface HeaderProps {
   isTeamEnd?: boolean;
   isAdmin?: boolean;
+  teamInfo: {
+    group_name: string;
+    division_name: string;
+    team_name: string;
+  };
 }
 
 // InquiryContent Props 타입
 export interface InquiryContentProps {
   title: string;
   content: string;
-  writer: {
+  author: {
     user_id: number;
-    name: string;
+    username: string;
     profile_image_url?: string;
-    team_name: string;
+    teamname: string;
   };
   createdAt: string;
   isWriter: boolean;
@@ -56,12 +62,12 @@ export interface InquiryHeaderProps {
     bg: string;
     text: string;
     dot: string;
-    border?: string; // 등록 보류 상태에만 적용
+    border?: string;
   };
   isWriter: boolean;
   isAdmin: boolean;
   canSendNotification: boolean;
-  isScrapped: boolean;
+  inquiry: InquiryData;
 }
 
 // NotificationButton Props 타입
@@ -82,18 +88,19 @@ export interface PendingActionsProps {
 export interface AssigneeSectionProps {
   assignees?: Array<{
     user_id: number;
-    name: string;
+    username: string; // [수정] 'name'을 'username'으로 통일
     profile_image_url?: string;
     is_confirmed: boolean;
   }>;
-  references?: Array<{
+  // [수정] 'references'를 실제 데이터 키인 'observers'로 변경
+  observers?: Array<{
     user_id: number;
-    name: string;
+    username: string; // [수정] 'name'을 'username'으로 통일
     profile_image_url?: string;
   }>;
   confirmedAssignees?: Array<{
     user_id: number;
-    name: string;
+    username: string; // [수정] 'name'을 'username'으로 통일
     profile_image_url?: string;
   }>;
   isPendingState: boolean;
@@ -108,39 +115,57 @@ export interface InquiryData {
   content: string;
   created_at: string;
   inquiry_state: string;
-  writer: {
+  author: {
     user_id: number;
-    name: string;
+    username: string;
     profile_image_url?: string;
-    team_name: string;
+    teamname: string;
   };
   assignees: Array<{
     user_id: number;
-    name: string;
+    username: string;
     profile_image_url?: string;
     is_confirmed: boolean;
   }>;
-  references: Array<{
+  // [수정] 'references'를 실제 데이터 키인 'observers'로 변경
+  observers: Array<{
     user_id: number;
-    name: string;
+    username: string; // [수정] 'name'을 'username'으로 통일
     profile_image_url?: string;
   }>;
   files: Array<{
     file_name: string;
     file_url: string;
   }>;
+  group: {
+    groupId: number;
+    groupName: string;
+    active: boolean;
+  };
+  division: {
+    divisionId: number;
+    divisionName: string;
+    active: boolean;
+  };
+  team: {
+    teamId: number;
+    teamName: string;
+    active: boolean;
+  };
   can_edit: boolean;
   can_answer: boolean;
   can_notify: boolean;
-  is_scrapped: boolean;
+  is_scraped: boolean;
   confirmed_assignees_count: number;
   confirmed_assignees: Array<{
     user_id: number;
-    name: string;
+    username: string; // [수정] 'name'을 'username'으로 통일
     profile_image_url?: string;
   }>;
-  comment_count: number;
-  comments: Comment[];
+  answers: {
+    count: number;
+    answers: Comment[];
+  };
   follow_ups: FollowUp[];
 
   // 테스트용 필드들 (mock 데이터에서만 사용, 컴포넌트에서는 옵셔널)

--- a/src/types/inquiryTypes.ts
+++ b/src/types/inquiryTypes.ts
@@ -3,11 +3,10 @@ export type UserRole = "default" | "assignee" | "writer" | "admin";
 // 답변 타입
 export interface Comment {
   comment_id: number;
-  // [수정] 'writer'를 'author'로, 'name'을 'username'으로 통일
-  author: {
+  user: {
     user_id: number;
     username: string;
-    profile_image_url?: string;
+    profile_url?: string;
     team_name?: string;
   };
   content: string;
@@ -22,7 +21,7 @@ export interface FollowUp {
   created_at: string;
   author: {
     user_id: number;
-    username: string;
+    user_name: string;
     profile_image_url?: string;
   };
   comments: Comment[];
@@ -37,6 +36,7 @@ export interface HeaderProps {
     division_name: string;
     team_name: string;
   };
+  onDelete: () => void;
 }
 
 // InquiryContent Props 타입
@@ -45,14 +45,15 @@ export interface InquiryContentProps {
   content: string;
   author: {
     user_id: number;
-    username: string;
+    user_name: string;
     profile_image_url?: string;
-    teamname: string;
+    team_name: string;
   };
   createdAt: string;
   isWriter: boolean;
   isAdmin: boolean;
   answersCount: number;
+  onDelete: () => void;
 }
 
 // InquiryHeader Props 타입
@@ -88,24 +89,31 @@ export interface PendingActionsProps {
 export interface AssigneeSectionProps {
   assignees?: Array<{
     user_id: number;
-    username: string; // [수정] 'name'을 'username'으로 통일
+    user_name: string;
     profile_image_url?: string;
-    is_confirmed: boolean;
+    is_checked: boolean;
   }>;
-  // [수정] 'references'를 실제 데이터 키인 'observers'로 변경
   observers?: Array<{
-    user_id: number;
-    username: string; // [수정] 'name'을 'username'으로 통일
-    profile_image_url?: string;
+    userId: number;
+    userName: string;
+    profileImageUrl?: string;
   }>;
   confirmedAssignees?: Array<{
     user_id: number;
-    username: string; // [수정] 'name'을 'username'으로 통일
+    username: string;
     profile_image_url?: string;
   }>;
   isPendingState: boolean;
-  isAssigneeEditMode: boolean;
+}
+
+// AssigneeActionsProps 타입
+export interface AssigneeActionsProps {
   showAssigneeFeatures: boolean;
+  onStartAnswer: (commentToEdit?: Comment) => void;
+  onConfirm: () => void;
+  isCurrentUserConfirmed: boolean;
+  showEditor: boolean;
+  hasMyComment: boolean;
 }
 
 // 통합된 문의 타입 (API 스펙에 완전히 맞춤)
@@ -114,44 +122,44 @@ export interface InquiryData {
   title: string;
   content: string;
   created_at: string;
-  inquiry_state: string;
+  status: string;
   author: {
     user_id: number;
-    username: string;
+    user_name: string;
     profile_image_url?: string;
-    teamname: string;
+    team_name: string;
   };
   assignees: Array<{
     user_id: number;
-    username: string;
+    user_name: string;
     profile_image_url?: string;
-    is_confirmed: boolean;
+    is_checked: boolean;
   }>;
-  // [수정] 'references'를 실제 데이터 키인 'observers'로 변경
   observers: Array<{
-    user_id: number;
-    username: string; // [수정] 'name'을 'username'으로 통일
-    profile_image_url?: string;
+    userId: number;
+    userName: string;
+    profileImageUrl?: string;
   }>;
   files: Array<{
     file_name: string;
     file_url: string;
   }>;
   group: {
-    groupId: number;
-    groupName: string;
+    group_id: number;
+    group_name: string;
     active: boolean;
   };
   division: {
-    divisionId: number;
-    divisionName: string;
+    division_d: number;
+    division_name: string;
     active: boolean;
   };
   team: {
-    teamId: number;
-    teamName: string;
+    team_id: number;
+    team_name: string;
     active: boolean;
   };
+  role: string;
   can_edit: boolean;
   can_answer: boolean;
   can_notify: boolean;
@@ -159,7 +167,7 @@ export interface InquiryData {
   confirmed_assignees_count: number;
   confirmed_assignees: Array<{
     user_id: number;
-    username: string; // [수정] 'name'을 'username'으로 통일
+    username: string;
     profile_image_url?: string;
   }>;
   answers: {
@@ -179,4 +187,76 @@ export interface InquiryCardProps {
   inquiry: InquiryData;
   userRole?: UserRole;
   currentUserId?: number;
+  handleStartAnswer: (commentToEdit?: Comment) => void;
+  onConfirm: () => void;
+  handleDeleteInquiry: () => void;
+  handleNotify: () => void;
+  remainingTime: string;
+  notificationSent: boolean;
+  showEditor: boolean;
+  myComment?: Comment;
+}
+
+// AnswerListProps 타입
+export interface AnswerListProps {
+  answerers: {
+    user_id: number;
+    username: string;
+    profile_image_url?: string;
+  }[];
+  selectedUserId: number | null;
+  onSelectUser: (id: number) => void;
+}
+
+// AnswerItemProps 타입
+export interface AnswerItemProps {
+  comment: Comment;
+  isOnlyComment: boolean;
+  currentUserId?: number;
+  onStartEdit: (comment: Comment) => void;
+  onDelete: (answerId: number) => void;
+}
+
+// AnswerEditorProps 타입
+export interface AnswerEditorProps {
+  initialContent: string;
+  onContentChange: (content: string) => void;
+  onSubmit: (content: string) => void;
+}
+
+// AnswerSectionProps 타입
+export interface AnswerSectionProps {
+  inquiry: InquiryData;
+  currentUserId?: number;
+  showEditor: boolean;
+  tabsToDisplay: {
+    user_id: number;
+    username: string;
+    profile_image_url?: string;
+  }[];
+  selectedUserId: number | null;
+  selectedComment: Comment | null;
+  draftContent: string;
+  setDraftContent: (content: string) => void;
+  handleStartAnswer: (commentToEdit?: Comment) => void;
+  handleSelectTab: (userId: number) => void;
+  onEditorSubmit: (content: string) => void;
+  onDeleteAnswer: (answerId: number) => void;
+  editingComment: Comment | null;
+}
+
+// NotificationButton Props 타입
+export interface NotificationButtonProps {
+  isWriter: boolean;
+  notificationSent: boolean;
+  remainingTime: string;
+  finalStateLabel: string;
+  onSend: () => void;
+}
+
+// 담당자 선택 컴포넌트에서 사용할 User 타입
+export interface User {
+  id: number;
+  user_name: string;
+  profile_image_url?: string;
 }

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -1,5 +1,13 @@
 export interface ModalButton {
-  type: "blue" | "white" | "gray";
+  type: "blue" | "white" | "gray" | "red";
   label: string;
   onClick: () => void;
+}
+
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  description?: string;
+  buttons: ModalButton[];
 }

--- a/src/types/profile/profileApi.type.ts
+++ b/src/types/profile/profileApi.type.ts
@@ -1,0 +1,14 @@
+/**
+ * GET /api/profile/preview (내 프로필)
+ */
+export interface GetMyProfileResponse {
+  id: number;
+  name: string;
+  group_name: string;
+  division_name: string;
+  team_id: number;
+  team_name: string;
+  email: string;
+  phone_number: string;
+  profile_image_url: string | null;
+}

--- a/src/types/scrap/scrapApi.type.ts
+++ b/src/types/scrap/scrapApi.type.ts
@@ -1,0 +1,19 @@
+/**
+ * POST /api/scrap/{inquiry_id}
+ */
+export interface PostScrapResponse {
+  scrap_id: number;
+  inquiry_id: number;
+  user_id: number;
+  created_at: string;
+}
+
+/**
+ * DELETE /api/scrap/{inquiry_id}
+ */
+export interface DeleteScrapResponse {
+  scrap_id: number;
+  inquiry_id: number;
+  user_id: number;
+  created_at: string; // 삭제 일시
+}

--- a/src/utils/modalUtils.ts
+++ b/src/utils/modalUtils.ts
@@ -14,5 +14,7 @@ export const getButtonClass = (
       return `${base} bg-white border border-main text-main hover:bg-gray-10`;
     case "gray":
       return `${base} bg-gray-30 text-white hover:bg-gray-50`;
+    case "red":
+      return `${base} bg-point-red text-white hover:bg-point-red-dark`;
   }
 };


### PR DESCRIPTION
## 💡 To Reviewers

- 페이지의 모든 상태 관리, 데이터 호출, 핸들러 함수를 `useInquiryDetail.ts` 커스텀 훅으로 분리하여 `InquiryDetailPage.tsx`의 코드를 간결하게 리팩토링했습니다.
- /api/teams/{team_id}/inquiries/1~200 까지 문의글 mockData가 지금 반영이 안되었다고 합니다. 
브라우저 콘솔에서 게시글 POST 요청보내서, 게시글 새로 만든 후에 테스트해봐야 합니다.

예시 코드
```
fetch('https://mutsa.store/api/teams/1/inquiries', {
  method: 'POST',
  headers: {
    'Content-Type': 'application/json',
    'Authorization': 'Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJCRTAwMDAxIiwiZXhwIjoxNzU0ODA4MjAxLCJ0b2tlblR5cGUiOiJBQ0NFU1MiLCJpYXQiOjE3NTQ3OTM4MDF9.KHQJvTdNEM7BcxllerhtlQqUwgLGVgZkczgGmUxyg8sHFsh4Bift8H1WDG6cNoUhyabWsNA33X93JtRfjdJTbQ'  // 로그인 토큰
  },
  body: JSON.stringify({
    title: "답변 테스트용 문의글",
    content: "이 문의글에 답변을 달아서 답변 기능을 테스트",
    assignee_ids: [1, 3],
    observer_ids: [4]
  })
})
.then(r => r.json())
.then(data => console.log('문의글 ID:', data.result.inquiry_id))
```
team_id : 1 => 백엔드 개발팀
user_id : 1 => 김개발 (아이디 BE00001)
user_id : 2 => 이백엔드 (아이디 BE00002)
user_id : 3 => 박스프링 (아이디 BE00003)
user_id : 4 => 최자바 (아이디 BE00004) -> 팀 관리자 권한 가짐

EX) 이백엔드 ID로 로그인 후 네트워크 탭에서 토큰 복사 후, 위 예시 코드를 이용해 콘솔창에 입력하면,
답변 담당자:  김개발, 박스프링 / 답변 참조자: 최자바
---

## 🔥 작업 내용

### 1. 문의 상세 페이지 API 연동 및 로직 분리
- `GET /api/teams/{team_id}/inquiries/{inquiry_id}` API를 연동하여 문의 상세 데이터를 조회

### 2. 사용자 정보 연동
- `GET /api/profile/preview` API를 호출하는 `useMyProfile` 훅을 생성하여, 현재 로그인한 사용자의 ID(`currentUserId`)를 동적으로 받아옴

### 3. 동적 상태 관리 로직 구현
- `useInquiryState.ts` 훅을 통해, 서버 데이터(담당자 확인 수, 답변 개수 등)를 기반으로 문의글의 최종 상태(확인 중, 등록 보류, 답변 완료 등)가 동적으로 계산되도록 구현했습니다.
- 계산된 상태에 따라 `InquiryHeader`의 상태 라벨과 `AssigneeActions`의 버튼 표시 여부가 변경.

### 4. 답변 기능 (등록, 수정) API 연동
- `POST /.../answers` (답변 등록) 및 `PUT /api/answers/{answer_id}` (답변 수정) API를 연동했습니다.
- `AnswerEditor` 컴포넌트와 연동하여, *'답변 등록하기'* 버튼 클릭 시 모달창으로 재확인 후 API가 호출되도록 구현했습니다.

### 5. 담당자 기능 (문의 확인, 담당자 정렬) API 연동
- `POST /.../confirm` API를 연동하여 *'문의 확인 처리'* 기능을 구현했습니다.
- React Query의 `setQueryData`를 사용하여, '확인' 성공 시 네트워크 요청 없이 즉시 UI(버튼 사라짐, 담당자 이름 색상 변경)가 업데이트되도록 최적화했습니다.
- `AssigneeSection`에서 확인한 담당자가 확인 안 한 담당자보다 앞에 오도록 목록을 정렬하는 기능을 추가했습니다.

### 6. 게시글 삭제 기능 API 연동
- `DELETE /api/inquiries/{id}` API를 연동했습니다.
- 문의글의 작성자 또는 관리자에게만 보이는 *'삭제'* 버튼에 기능을 연결하고, 성공 시 팀 목록 페이지로 이동하도록 구현했습니다.

### 7. 담당자 알림 발송 기능 및 실시간 카운트다운 구현
- `POST /.../mails` (알림 발송) 및 `GET /.../mails/last-sent-time` (마지막 발송 시간 조회) API를 연동했습니다.
- `useEffect`와 `setInterval`을 사용하여, 알림 발송 후 다음 발송까지 남은 시간을 실시간으로 계산하여 버튼에 카운트다운을 표시하는 기능을 구현했습니다.

---

## 🤔 추후 작업 예정
- **답변 삭제 기능**: 현재 각 답변에 '삭제' 버튼은 있지만, `DELETE /api/answers/{answer_id}` API 연동이 필요합니다.
- **문의글 수정 기능**: '수정' 버튼 클릭 시, 기존 내용을 불러와 수정할 수 있는 `InquiryFormPage`의 '수정 모드' 구현이 필요합니다.
- **담당자 수정 기능**: 모달창 UI는 구현되었지만, 실제 담당자를 검색하고 선택하는 기능과 `PUT /.../change-assignee` API 연동을 마무리해야 합니다.

---

## 📸 작업 결과 (선택)
바로 수정해서 올리겠습니다.

---

## 🔗 관련 이슈 (선택)
#51 