### PR TITLE
[Fix] 문의 임시저장 전반적인 흐름 수정

### DIFF
--- a/src/components/inquiry/form/FileUploadBox.tsx
+++ b/src/components/inquiry/form/FileUploadBox.tsx
@@ -15,7 +15,7 @@ interface Props {
   setFiles: React.Dispatch<React.SetStateAction<UploadingFile[]>>;
 }
 
-const FileUploadBox = ({ setFileIds, files, setFiles }: Props) => {
+const FileUploadBox = ({ setFileIds, files, fileIds, setFiles }: Props) => {
   const {
     inputRef,
     showLimitModal,
@@ -23,7 +23,7 @@ const FileUploadBox = ({ setFileIds, files, setFiles }: Props) => {
     triggerInput,
     handleFileSelect,
     handleRemove,
-  } = useMultiFileUploader(files, setFileIds, setFiles);
+  } = useMultiFileUploader(files, fileIds, setFileIds, setFiles);
 
   const { isDragging, dragEventProps } = useDragAndDrop({
     onDrop: handleFileSelect,

--- a/src/components/inquiry/form/InquiryFormModal.tsx
+++ b/src/components/inquiry/form/InquiryFormModal.tsx
@@ -1,51 +1,92 @@
 import Modal from "@/components/common/Modal";
 
 interface Props {
+  // 공통
   missingField: "team" | "title" | "content" | "assignee" | null;
   onCloseMissing: () => void;
+
+  // 임시저장 관련
   isDraftOpen: boolean;
+  draftModalMode: "detect" | "conflict"; // ✅ 추가: 감지 / 충돌 모드
   onCloseDraft: () => void;
-  onRestoreDraft: () => void;
-  onResetDraft: () => void;
+  onRestoreDraft: () => void; // 불러오기
+  onResetDraft: () => void; // 현재 글 유지(닫기만)
+  onOverwriteDraft: () => void; // ✅ 추가: 현재 글로 임시저장 (덮어쓰기)
+
+  // 등록 확인
   isConfirmOpen: boolean;
   onCloseConfirm: () => void;
   onConfirmSubmit: () => void;
+
+  // 공통 진행 상태
   isSubmitting?: boolean;
 }
 
 const InquiryFormModal = ({
+  // 공통
   missingField,
   onCloseMissing,
+
+  // 임시저장
   isDraftOpen,
+  draftModalMode,
   onCloseDraft,
   onRestoreDraft,
   onResetDraft,
+  onOverwriteDraft,
+
+  // 등록 확인
   isConfirmOpen,
   onCloseConfirm,
   onConfirmSubmit,
+
+  // 상태
   isSubmitting,
 }: Props) => {
   return (
     <>
-      {/* 임시저장 감지 모달 */}
-      <Modal
-        isOpen={isDraftOpen}
-        onClose={isSubmitting ? () => {} : onCloseDraft}
-        title={"임시저장된 글이 있습니다.\n불러오시겠습니까?"}
-        description="새로 작성하면 기존 임시저장된 글은 사라집니다."
-        buttons={[
-          {
-            label: "새로 작성",
-            type: "white",
-            onClick: onResetDraft,
-          },
-          {
-            label: "불러오기",
-            type: "blue",
-            onClick: onRestoreDraft,
-          },
-        ]}
-      />
+      {/* 임시저장 감지/충돌 모달 */}
+      {draftModalMode === "detect" ? (
+        <Modal
+          isOpen={isDraftOpen}
+          onClose={isSubmitting ? () => {} : onCloseDraft}
+          title={"임시저장된 글이 있습니다.\n불러오시겠습니까?"}
+          description="저장된 글을 불러올 시 작성중이던 게시글은 삭제됩니다."
+          buttons={[
+            {
+              label: "현재 글 유지",
+              type: "white",
+              onClick: isSubmitting ? () => {} : onResetDraft,
+            },
+            {
+              label: "불러오기",
+              type: "blue",
+              onClick: isSubmitting ? () => {} : onRestoreDraft,
+            },
+          ]}
+        />
+      ) : (
+        <Modal
+          isOpen={isDraftOpen}
+          onClose={isSubmitting ? () => {} : onCloseDraft}
+          title={"해당 팀으로 임시저장된 글이 있습니다.\n덮어쓰시겠습니까?"}
+          description={
+            "임시저장 가능 갯수는 1개까지로\n이전에 임시저장한 글은 삭제됩니다."
+          }
+          buttons={[
+            {
+              label: "뒤로가기",
+              type: "white",
+              onClick: isSubmitting ? () => {} : onCloseDraft,
+            },
+            {
+              label: "덮어쓰기",
+              type: "blue",
+              onClick: isSubmitting ? () => {} : onOverwriteDraft,
+            },
+          ]}
+        />
+      )}
 
       {/* 필수 항목 누락 시 모달 */}
       <Modal
@@ -75,7 +116,8 @@ const InquiryFormModal = ({
         onClose={onCloseConfirm}
         title="게시판에 문의를 등록할까요?"
         description={
-          "등록 시 담당자와 참조자에게 알림이 발송되며,\n답변이 달린 이후에는 글을 수정 및 삭제할 수 없습니다."
+          "등록 시 담당자와 참조자에게 알림이 발송되며,\n" +
+          "답변이 달린 이후에는 글을 수정 및 삭제할 수 없습니다."
         }
         buttons={[
           {

--- a/src/hooks/file/useMultiFileUploader.ts
+++ b/src/hooks/file/useMultiFileUploader.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { UploadingFile } from "@/types/file/file.type";
 
@@ -10,36 +10,58 @@ const MAX_FILE_COUNT = 6;
 
 export const useMultiFileUploader = (
   files: UploadingFile[],
-  setFileIds: React.Dispatch<React.SetStateAction<number[]>>,
+  fileIds: number[],
+  setFileIds: (next: number[]) => void,
   setFiles: React.Dispatch<React.SetStateAction<UploadingFile[]>>
 ) => {
   const [showLimitModal, setShowLimitModal] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const uploadFile = useS3UploadFile();
 
+  // 최신 fileIds를 항상 참조하기 위한 ref
+  const fileIdsRef = useRef<number[]>(fileIds);
+  useEffect(() => {
+    fileIdsRef.current = fileIds;
+  }, [fileIds]);
+
   const triggerInput = () => inputRef.current?.click();
 
   const updateProgress = (id: number, progress: number) => {
-    setFiles(prev =>
-      prev.map(file => (file.id === id ? { ...file, progress } : file))
-    );
+    setFiles(prev => prev.map(f => (f.id === id ? { ...f, progress } : f)));
+  };
+
+  // ref 기반 안전한 추가/삭제 유틸
+  const pushFileId = (id: number) => {
+    const base = fileIdsRef.current ?? [];
+    if (base.includes(id)) return;
+    const next = [...base, id];
+    fileIdsRef.current = next;
+    setFileIds(next);
+  };
+  const removeFileId = (id: number) => {
+    const base = fileIdsRef.current ?? [];
+    const next = base.filter(x => x !== id);
+    fileIdsRef.current = next;
+    setFileIds(next);
   };
 
   const handleFileSelect = async (fileList: FileList | null) => {
     if (!fileList) return;
-    const filesArray = Array.from(fileList);
 
+    const filesArray = Array.from(fileList);
+    // 현재 카드 수 기준으로 개수 제한
     if (files.length + filesArray.length > MAX_FILE_COUNT) {
       setShowLimitModal(true);
       return;
     }
 
+    // 로컬 아이디 생성 & UI 선반영
     const localIds: number[] = [];
     const newFiles: UploadingFile[] = filesArray.map(file => {
       const id = Date.now() + Math.random();
       localIds.push(id);
       return {
-        id: id,
+        id,
         file_name: file.name,
         file_size: file.size,
         progress: 0,
@@ -47,25 +69,24 @@ export const useMultiFileUploader = (
         controller: undefined,
       };
     });
-
     setFiles(prev => [...prev, ...newFiles]);
 
     await Promise.all(
-      filesArray.map((file, index) => {
-        const localId = localIds[index];
+      filesArray.map((file, idx) => {
+        const localId = localIds[idx];
         const controller = new AbortController();
         const signal = controller.signal;
 
+        // AbortController 저장
         setFiles(prev =>
           prev.map(f => (f.id === localId ? { ...f, controller } : f))
         );
 
-        return uploadFile(
-          file,
-          percent => updateProgress(localId, percent),
-          signal
-        )
+        return uploadFile(file, p => updateProgress(localId, p), signal)
           .then(({ file_id }) => {
+            if (!file_id) return;
+
+            // UI 완료 반영
             setFiles(prev =>
               prev.map(f =>
                 f.id === localId
@@ -79,11 +100,12 @@ export const useMultiFileUploader = (
                   : f
               )
             );
-            setFileIds(prev => [...prev, file_id]);
+
+            pushFileId(file_id);
           })
           .catch(err => {
-            if (err.name === "CanceledError") {
-              console.log("업로드 취소됨:", file.name);
+            if (err?.name === "CanceledError") {
+              console.log("업로드 취소:", file.name);
             } else {
               console.error("파일 업로드 실패:", err);
             }
@@ -100,22 +122,25 @@ export const useMultiFileUploader = (
   };
 
   const handleRemove = async (localId: number, fileId?: number) => {
-    const target = files.find(file => file.id === localId);
+    const target = files.find(f => f.id === localId);
 
+    // 업로드 중이면 취소
     if (target?.status === "uploading" && target.controller) {
       target.controller.abort();
     }
 
+    // 서버 삭제 시도 후 상태 갱신
     if (fileId) {
       try {
         await deleteFile(fileId);
-        setFileIds(prev => prev.filter(id => id !== fileId));
       } catch (e) {
         console.error("파일 삭제 실패", e);
+        // 정책에 따라 실패 시 그대로 두고 리턴할 수도 있음
       }
+      removeFileId(fileId);
     }
 
-    setFiles(prev => prev.filter(file => file.id !== localId));
+    setFiles(prev => prev.filter(f => f.id !== localId));
   };
 
   return {

--- a/src/hooks/inquiry/create/useInquiryDraft.ts
+++ b/src/hooks/inquiry/create/useInquiryDraft.ts
@@ -10,7 +10,7 @@ export interface UseInquiryDraftParams {
   content: string;
   assigneeIds: number[];
   referenceIds: number[];
-  fileIds: number[]; // 외부에서 계속 관리 중이면 동기화 유지
+  fileIds: number[];
   setTitle: (v: string) => void;
   setContent: (v: string) => void;
   setAssigneeIds: (v: number[]) => void;
@@ -59,7 +59,13 @@ export const useInquiryDraft = ({
   const [isDraftModalOpen, setIsDraftModalOpen] = useState(false);
   const [isDraftSaved, setIsDraftSaved] = useState(false);
   const [justSavedDraft, setJustSavedDraft] = useState(false);
-  const [hasActivatedDraft, setHasActivatedDraft] = useState(false); // post/restore 이후부터 PUT 고정
+  const [hasActivatedDraft, setHasActivatedDraft] = useState(false); // restore/reset 이후부터 PUT 고정
+
+  const [draftModalMode, setDraftModalMode] = useState<"detect" | "conflict">(
+    "detect"
+  );
+  const autoOpenSuppressedRef = useRef(false);
+  const lastServerDraftIdRef = useRef<number | null>(null);
 
   // 항상 최신 스냅샷 비교용
   const prevRef = useRef({
@@ -74,7 +80,6 @@ export const useInquiryDraft = ({
   const setFilesSync = (next: UploadFile[]) => {
     filesRef.current = next;
     setFiles(next);
-    // 외부 fileIds도 계속 쓰고 있다면 동기화(중복 제거)
     const ids = Array.from(
       new Set(
         next
@@ -105,8 +110,13 @@ export const useInquiryDraft = ({
     usePutInquiryDraftMutation,
   } = useInquiryDraftApi();
 
-  const { data: draftExists, refetch: refetchDraftExists } =
-    useCheckDraftExists(teamId, false);
+  const {
+    data: draftExists,
+    refetch: refetchDraftExists,
+    isLoading: isExistsLoading,
+    isFetching: isExistsFetching,
+    isSuccess: isExistsSuccess,
+  } = useCheckDraftExists(teamId, !!teamId);
 
   const { refetch: fetchDraft } = useGetInquiryDraft(
     teamId,
@@ -118,11 +128,47 @@ export const useInquiryDraft = ({
   const { mutate: putDraft } = usePutInquiryDraftMutation();
   const { mutate: deleteDraft } = useDeleteInquiryDraftMutation();
 
+  // 팀 변경 시 자동오픈 억제 해제
   useEffect(() => {
-    if (teamId && draftExists?.result?.is_present) {
-      setDraftId(draftExists.result.draft_id);
+    autoOpenSuppressedRef.current = false;
+  }, [teamId]);
+
+  // 팀 선택 시: 서버 초안 존재하면 모달 자동 오픈
+  useEffect(() => {
+    if (!teamId) return;
+    if (hasActivatedDraft || isDraftModalOpen) return;
+    if (!isExistsSuccess || isExistsLoading || isExistsFetching) return;
+
+    if (draftExists?.result?.is_present && !autoOpenSuppressedRef.current) {
+      lastServerDraftIdRef.current = draftExists.result.draft_id;
+      setDraftModalMode("detect");
+      setIsDraftModalOpen(true);
     }
-  }, [teamId, draftExists?.result?.is_present, draftExists?.result?.draft_id]);
+  }, [
+    teamId,
+    hasActivatedDraft,
+    isDraftModalOpen,
+    isExistsSuccess,
+    isExistsLoading,
+    isExistsFetching,
+    draftExists?.result?.is_present,
+    draftExists?.result?.draft_id,
+  ]);
+
+  useEffect(() => {
+    if (!teamId) return;
+
+    // 팀 바뀌면 이전 팀의 저장 상태/활성화/ID 모두 리셋
+    setDraftId(null);
+    setHasActivatedDraft(false);
+    setIsDraftSaved(false);
+    setJustSavedDraft(false);
+    setDraftModalMode("detect");
+    autoOpenSuppressedRef.current = false;
+
+    // 변경 감지 기준을 새 팀 기준으로 재설정
+    prevRef.current = { title, content, assigneeIds, referenceIds, fileIds };
+  }, [teamId]);
 
   // 저장됨 표시 이후 변경 감지
   useEffect(() => {
@@ -164,27 +210,34 @@ export const useInquiryDraft = ({
    * 임시저장 버튼
    * - 업로드 중이면 저장 막음
    * - 서버에 임시저장 없음 → POST
-   * - 서버에 임시저장 있음 & 활성화 전 → 모달
+   * - 서버에 임시저장 있음 & 활성화 전 → 충돌 모달(conflict)
    * - 활성화 이후 → PUT
    */
   const handleClickTempSave = async () => {
+    if (justSavedDraft) return;
+    if (getHasUploading()) return;
+
+    // 최신 서버 상태 조회
+    const { data: latest } = await refetchDraftExists();
+    const serverHas = Boolean(latest?.result?.is_present);
+    const serverId = latest?.result?.draft_id ?? null;
+    lastServerDraftIdRef.current = serverId;
+
+    // 서버 초안 존재 + 아직 활성화 전이면 → 충돌 모달
+    if (serverHas && !hasActivatedDraft) {
+      setDraftModalMode("conflict");
+      setIsDraftModalOpen(true);
+      return;
+    }
+
+    // 필드 검증
     const missing = validateFields();
     if (missing) {
       setMissingField(missing);
       return;
     }
-    if (justSavedDraft) return;
 
-    // 업로드 중 차단
-    if (getHasUploading()) {
-      return;
-    }
-
-    const { data: latest } = await refetchDraftExists();
-    const serverHas = Boolean(latest?.result?.is_present);
-    const serverId = latest?.result?.draft_id ?? null;
-
-    // 1) 서버 드래프트 없음 → POST
+    // 서버 초안 없음 → POST
     if (!serverHas) {
       const payload = buildDraftPayload();
       postDraft(
@@ -198,7 +251,7 @@ export const useInquiryDraft = ({
               content,
               assigneeIds,
               referenceIds,
-              fileIds: payload.file_ids, // ref 기반
+              fileIds: payload.file_ids,
             });
           },
         }
@@ -206,15 +259,9 @@ export const useInquiryDraft = ({
       return;
     }
 
-    // 2) 서버 드래프트 있음 + 아직 활성화 전 → 모달
-    if (!hasActivatedDraft) {
-      setIsDraftModalOpen(true);
-      if (serverId != null) setDraftId(serverId);
-      return;
-    }
+    // 이미 활성화됨 → PUT
 
-    // 3) 이미 활성화됨 → PUT
-    const id = draftId ?? serverId;
+    const id = serverId ?? draftId;
     if (id == null) return;
 
     const payload = buildDraftPayload();
@@ -234,8 +281,44 @@ export const useInquiryDraft = ({
     );
   };
 
-  /** 모달: b. 불러오기 → get draft & 상태 세팅, 이후부터 PUT 고정 */
+  /** 충돌 모달: "현재 글 유지로 임시저장" (기존 초안 삭제 → 지금 글로 POST) */
+  const saveCurrentAsDraftReplacingExisting = async () => {
+    const serverId = lastServerDraftIdRef.current;
+
+    const doPost = () => {
+      const payload = buildDraftPayload();
+      postDraft(
+        { teamId, data: payload },
+        {
+          onSuccess: res => {
+            setDraftId(res.result.inquiry_id);
+            setHasActivatedDraft(true);
+            markSaved({
+              title,
+              content,
+              assigneeIds,
+              referenceIds,
+              fileIds: payload.file_ids,
+            });
+            setIsDraftModalOpen(false);
+          },
+        }
+      );
+    };
+
+    if (serverId) {
+      deleteDraft(
+        { inquiryId: serverId, teamId },
+        { onSuccess: doPost, onError: doPost }
+      );
+    } else {
+      doPost();
+    }
+  };
+
+  /** 모달: 불러오기 → get draft & 상태 세팅, 이후부터 PUT 고정 */
   const restoreDraft = async () => {
+    setHasActivatedDraft(true); // auto-open 차단 먼저
     setIsDraftModalOpen(false);
 
     const { data } = await fetchDraft();
@@ -251,7 +334,6 @@ export const useInquiryDraft = ({
     setAssigneeIds(restoredAssignees);
     setReferenceIds(restoredObservers);
 
-    // ref + 외부 fileIds 동시 동기화
     setFilesSync(
       restoredFiles.map(file => ({
         id: file.file_id,
@@ -268,7 +350,6 @@ export const useInquiryDraft = ({
     handleTeamChange(r.team.team_id);
 
     setDraftId(r.inquiry_id);
-    setHasActivatedDraft(true);
     markSaved({
       title: r.title,
       content: r.content,
@@ -278,49 +359,10 @@ export const useInquiryDraft = ({
     });
   };
 
-  /** 모달: a. 새로 작성 → delete draft + post draft, 이후부터 PUT 고정 */
-  const resetDraft = async () => {
-    if (!teamId) return;
-
-    const { data: latest } = await refetchDraftExists();
-    const serverId = latest?.result?.draft_id ?? draftId;
-
-    const afterPost = (fileIdsSnapshot: number[]) => {
-      setHasActivatedDraft(true);
-      markSaved({
-        title,
-        content,
-        assigneeIds,
-        referenceIds,
-        fileIds: fileIdsSnapshot,
-      });
-      setIsDraftModalOpen(false);
-    };
-
-    const doPost = () => {
-      const payload = buildDraftPayload();
-      postDraft(
-        { teamId, data: payload },
-        {
-          onSuccess: res => {
-            setDraftId(res.result.inquiry_id);
-            afterPost(payload.file_ids);
-          },
-        }
-      );
-    };
-
-    if (serverId) {
-      deleteDraft(
-        { inquiryId: serverId, teamId },
-        {
-          onSuccess: () => doPost(),
-          onError: () => doPost(), // 삭제 실패해도 새로 작성 강행
-        }
-      );
-    } else {
-      doPost();
-    }
+  /** 모달: 현재 글 유지 → 팝업만 닫기 (자동 재오픈 억제) */
+  const resetDraft = () => {
+    autoOpenSuppressedRef.current = true;
+    setIsDraftModalOpen(false);
   };
 
   /** 최종 등록 전: 임시저장 삭제 helper (delete draft + then callback) */
@@ -332,12 +374,8 @@ export const useInquiryDraft = ({
     deleteDraft(
       { inquiryId: draftId, teamId },
       {
-        onSuccess: () => {
-          onDone?.();
-        },
-        onError: () => {
-          onDone?.();
-        },
+        onSuccess: () => onDone?.(),
+        onError: () => onDone?.(),
       }
     );
   };
@@ -354,12 +392,15 @@ export const useInquiryDraft = ({
     isDraftModalOpen,
     setIsDraftModalOpen,
 
+    draftModalMode, // "detect" | "conflict"
+
     // 버튼 동작
     handleClickTempSave,
 
     // 모달 액션
-    restoreDraft,
-    resetDraft,
+    restoreDraft, // 불러오기
+    resetDraft, // 현재 글 유지(닫기만)
+    saveCurrentAsDraftReplacingExisting, // 충돌 모달의 "현재 글 유지로 임시저장"
 
     deleteDraftBeforeSubmit,
 

--- a/src/hooks/inquiry/create/useInquiryDraft.ts
+++ b/src/hooks/inquiry/create/useInquiryDraft.ts
@@ -10,7 +10,7 @@ export interface UseInquiryDraftParams {
   content: string;
   assigneeIds: number[];
   referenceIds: number[];
-  fileIds: number[];
+  fileIds: number[]; // 외부에서 계속 관리 중이면 동기화 유지
   setTitle: (v: string) => void;
   setContent: (v: string) => void;
   setAssigneeIds: (v: number[]) => void;
@@ -30,8 +30,9 @@ export interface UseInquiryDraftParams {
 
 const arrEq = (a: number[] = [], b: number[] = []) => {
   if (a.length !== b.length) return false;
-  const s = new Set(a);
-  for (const x of b) if (!s.has(x)) return false;
+  const as = [...a].sort((x, y) => x - y);
+  const bs = [...b].sort((x, y) => x - y);
+  for (let i = 0; i < as.length; i++) if (as[i] !== bs[i]) return false;
   return true;
 };
 
@@ -58,10 +59,9 @@ export const useInquiryDraft = ({
   const [isDraftModalOpen, setIsDraftModalOpen] = useState(false);
   const [isDraftSaved, setIsDraftSaved] = useState(false);
   const [justSavedDraft, setJustSavedDraft] = useState(false);
+  const [hasActivatedDraft, setHasActivatedDraft] = useState(false); // post/restore 이후부터 PUT 고정
 
-  // 한 번이라도 불러오거나(restore) 새로 생성(post)해서 활성화되면 이후엔 PUT 고정
-  const [hasActivatedDraft, setHasActivatedDraft] = useState(false);
-
+  // 항상 최신 스냅샷 비교용
   const prevRef = useRef({
     title,
     content,
@@ -69,6 +69,33 @@ export const useInquiryDraft = ({
     referenceIds,
     fileIds,
   });
+
+  const filesRef = useRef<UploadFile[]>([]);
+  const setFilesSync = (next: UploadFile[]) => {
+    filesRef.current = next;
+    setFiles(next);
+    // 외부 fileIds도 계속 쓰고 있다면 동기화(중복 제거)
+    const ids = Array.from(
+      new Set(
+        next
+          .filter(f => f.status === "done" && typeof f.file_id === "number")
+          .map(f => f.file_id as number)
+      )
+    );
+    if (!arrEq(fileIds, ids)) setFileIds(ids);
+  };
+
+  const getValidFileIds = () =>
+    Array.from(
+      new Set(
+        filesRef.current
+          .filter(f => f.status === "done" && typeof f.file_id === "number")
+          .map(f => f.file_id as number)
+      )
+    );
+
+  const getHasUploading = () =>
+    filesRef.current.some(f => f.status === "uploading");
 
   const {
     useCheckDraftExists,
@@ -97,6 +124,7 @@ export const useInquiryDraft = ({
     }
   }, [teamId, draftExists?.result?.is_present, draftExists?.result?.draft_id]);
 
+  // 저장됨 표시 이후 변경 감지
   useEffect(() => {
     if (!isDraftSaved) return;
 
@@ -123,19 +151,21 @@ export const useInquiryDraft = ({
     setTimeout(() => setJustSavedDraft(false), 400);
   };
 
+  // payload는 항상 filesRef에서 유효한 file_id만 사용
   const buildDraftPayload = () => ({
     title,
     content,
     assignee_ids: assigneeIds ?? [],
     observer_ids: referenceIds ?? [],
-    file_ids: fileIds ?? [],
+    file_ids: getValidFileIds(),
   });
 
   /**
-   * 임시저장 버튼 클릭 핸들러 (요구사항의 "임시저장 x → 클릭 시 바로 Post" / "임시저장 o → 모달")
-   * - 서버에 임시저장 없음 → 바로 POST
-   * - 서버에 임시저장 있음 & 아직 활성화 전(hasActivatedDraft=false) → 모달 오픈
-   * - 이미 활성화됨(hasActivatedDraft=true) → PUT
+   * 임시저장 버튼
+   * - 업로드 중이면 저장 막음
+   * - 서버에 임시저장 없음 → POST
+   * - 서버에 임시저장 있음 & 활성화 전 → 모달
+   * - 활성화 이후 → PUT
    */
   const handleClickTempSave = async () => {
     const missing = validateFields();
@@ -145,11 +175,16 @@ export const useInquiryDraft = ({
     }
     if (justSavedDraft) return;
 
+    // 업로드 중 차단
+    if (getHasUploading()) {
+      return;
+    }
+
     const { data: latest } = await refetchDraftExists();
     const serverHas = Boolean(latest?.result?.is_present);
     const serverId = latest?.result?.draft_id ?? null;
 
-    // 1) 서버 드래프트 없음 → 바로 POST
+    // 1) 서버 드래프트 없음 → POST
     if (!serverHas) {
       const payload = buildDraftPayload();
       postDraft(
@@ -157,13 +192,13 @@ export const useInquiryDraft = ({
         {
           onSuccess: res => {
             setDraftId(res.result.inquiry_id);
-            setHasActivatedDraft(true); // 이후부터 PUT
+            setHasActivatedDraft(true);
             markSaved({
               title,
               content,
               assigneeIds,
               referenceIds,
-              fileIds,
+              fileIds: payload.file_ids, // ref 기반
             });
           },
         }
@@ -171,10 +206,9 @@ export const useInquiryDraft = ({
       return;
     }
 
-    // 2) 서버 드래프트 있음 + 아직 활성화 전 → 모달 오픈
+    // 2) 서버 드래프트 있음 + 아직 활성화 전 → 모달
     if (!hasActivatedDraft) {
       setIsDraftModalOpen(true);
-      // 드래프트 id 동기화
       if (serverId != null) setDraftId(serverId);
       return;
     }
@@ -182,8 +216,10 @@ export const useInquiryDraft = ({
     // 3) 이미 활성화됨 → PUT
     const id = draftId ?? serverId;
     if (id == null) return;
+
+    const payload = buildDraftPayload();
     putDraft(
-      { inquiryId: id, teamId, data: buildDraftPayload() },
+      { inquiryId: id, teamId, data: payload },
       {
         onSuccess: () => {
           markSaved({
@@ -191,7 +227,7 @@ export const useInquiryDraft = ({
             content,
             assigneeIds,
             referenceIds,
-            fileIds,
+            fileIds: payload.file_ids,
           });
         },
       }
@@ -214,8 +250,9 @@ export const useInquiryDraft = ({
     setContent(r.content);
     setAssigneeIds(restoredAssignees);
     setReferenceIds(restoredObservers);
-    setFileIds(restoredFiles.map(f => f.file_id));
-    setFiles(
+
+    // ref + 외부 fileIds 동시 동기화
+    setFilesSync(
       restoredFiles.map(file => ({
         id: file.file_id,
         file_id: file.file_id,
@@ -231,13 +268,13 @@ export const useInquiryDraft = ({
     handleTeamChange(r.team.team_id);
 
     setDraftId(r.inquiry_id);
-    setHasActivatedDraft(true); // 이후 PUT
+    setHasActivatedDraft(true);
     markSaved({
       title: r.title,
       content: r.content,
       assigneeIds: restoredAssignees,
       referenceIds: restoredObservers,
-      fileIds: restoredFiles.map(f => f.file_id),
+      fileIds: Array.from(new Set(restoredFiles.map(f => f.file_id))),
     });
   };
 
@@ -248,25 +285,26 @@ export const useInquiryDraft = ({
     const { data: latest } = await refetchDraftExists();
     const serverId = latest?.result?.draft_id ?? draftId;
 
-    const afterPost = () => {
+    const afterPost = (fileIdsSnapshot: number[]) => {
       setHasActivatedDraft(true);
       markSaved({
         title,
         content,
         assigneeIds,
         referenceIds,
-        fileIds,
+        fileIds: fileIdsSnapshot,
       });
       setIsDraftModalOpen(false);
     };
 
     const doPost = () => {
+      const payload = buildDraftPayload();
       postDraft(
-        { teamId, data: buildDraftPayload() },
+        { teamId, data: payload },
         {
           onSuccess: res => {
             setDraftId(res.result.inquiry_id);
-            afterPost();
+            afterPost(payload.file_ids);
           },
         }
       );
@@ -277,6 +315,7 @@ export const useInquiryDraft = ({
         { inquiryId: serverId, teamId },
         {
           onSuccess: () => doPost(),
+          onError: () => doPost(), // 삭제 실패해도 새로 작성 강행
         }
       );
     } else {
@@ -316,15 +355,17 @@ export const useInquiryDraft = ({
     setIsDraftModalOpen,
 
     // 버튼 동작
-    handleClickTempSave, // 임시저장 버튼 onClick에 연결
+    handleClickTempSave,
 
     // 모달 액션
-    restoreDraft, // 불러오기
-    resetDraft, // 새로 작성
+    restoreDraft,
+    resetDraft,
 
-    // 최종 등록 전 삭제용
     deleteDraftBeforeSubmit,
 
     clearDraftState,
+
+    setFilesSync,
+    hasUploadingFiles: getHasUploading,
   };
 };

--- a/src/pages/inquiry/InquiryFormPage.tsx
+++ b/src/pages/inquiry/InquiryFormPage.tsx
@@ -163,6 +163,8 @@ const InquiryFormPage = () => {
     resetDraft,
     deleteDraftBeforeSubmit,
     clearDraftState,
+    setFilesSync,
+    hasUploadingFiles,
   } = useInquiryDraft({
     teamId: teamId ?? 0,
     title,
@@ -199,6 +201,19 @@ const InquiryFormPage = () => {
   const getUserId = (u?: { user_id?: number; userId?: number } | null) =>
     (u?.user_id ?? u?.userId ?? 0) as number;
 
+  const fileIdsForSubmit = useMemo(
+    () =>
+      (files ?? [])
+        .filter(
+          f =>
+            f.status === "done" &&
+            typeof f.file_id === "number" &&
+            f.file_id! > 0
+        )
+        .map(f => f.file_id!),
+    [files]
+  );
+
   // 편집 모드 데이터 주입
   useEffect(() => {
     if (!isEdit || !editDetail) return;
@@ -219,16 +234,17 @@ const InquiryFormPage = () => {
 
     const detailFiles = (editDetail.files as InquiryFile[] | undefined) ?? [];
     setFileIds(detailFiles.map(f => f.file_id));
-    setFiles(
+
+    setFilesSync(
       detailFiles.map(f => ({
         id: f.file_id,
+        file_id: f.file_id,
         file_name: f.file_name,
         file_size: f.file_size ?? 0,
         progress: 100,
         status: "done" as const,
       }))
     );
-
     if (
       editDetail.group?.group_id &&
       editDetail.division?.division_id &&
@@ -266,12 +282,17 @@ const InquiryFormPage = () => {
       setMissingField(missing);
       return;
     }
+    if (hasUploadingFiles()) {
+      setMissingField(null);
+      setIsConfirmModalOpen(false);
+      return;
+    }
     if (isEdit && editTeamId && editInquiryId) {
       confirmSubmit();
       return;
     }
     setIsConfirmModalOpen(true);
-  }, [validateFields, isEdit, editTeamId, editInquiryId]);
+  }, [validateFields, isEdit, editTeamId, editInquiryId, hasUploadingFiles]);
 
   const confirmSubmit = useCallback(() => {
     const payload: PostInquiryRequest = {
@@ -279,7 +300,7 @@ const InquiryFormPage = () => {
       content,
       assignee_ids: assigneeIds,
       observer_ids: referenceIds,
-      file_ids: fileIds,
+      file_ids: fileIdsForSubmit,
     };
 
     if (isEdit && editTeamId && editInquiryId) {
@@ -317,6 +338,7 @@ const InquiryFormPage = () => {
     content,
     assigneeIds,
     referenceIds,
+    fileIdsForSubmit,
     fileIds,
     putInquiryMutation,
     postInquiryMutation,

--- a/src/pages/inquiry/InquiryFormPage.tsx
+++ b/src/pages/inquiry/InquiryFormPage.tsx
@@ -165,6 +165,8 @@ const InquiryFormPage = () => {
     clearDraftState,
     setFilesSync,
     hasUploadingFiles,
+    draftModalMode,
+    saveCurrentAsDraftReplacingExisting,
   } = useInquiryDraft({
     teamId: teamId ?? 0,
     title,
@@ -428,6 +430,8 @@ const InquiryFormPage = () => {
         onCloseConfirm={() => setIsConfirmModalOpen(false)}
         onConfirmSubmit={confirmSubmit}
         isSubmitting={isBlocking}
+        draftModalMode={draftModalMode}
+        onOverwriteDraft={saveCurrentAsDraftReplacingExisting}
       />
     </section>
   );

--- a/src/pages/inquiry/InquiryFormPage.tsx
+++ b/src/pages/inquiry/InquiryFormPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import clsx from "clsx";
 import { useLocation, useSearchParams } from "react-router-dom";
@@ -46,6 +46,7 @@ const InquiryFormPage = () => {
 
   const mode = searchParams.get("mode");
   const isEdit = mode === "edit";
+  const appliedEditRef = useRef(false);
 
   const teamIdQS = searchParams.get("teamId");
   const inquiryIdQS = searchParams.get("inquiryId");
@@ -201,6 +202,7 @@ const InquiryFormPage = () => {
   // 편집 모드 데이터 주입
   useEffect(() => {
     if (!isEdit || !editDetail) return;
+    if (appliedEditRef.current) return;
 
     setTitle(editDetail.title ?? "");
     setContent(editDetail.content ?? "");
@@ -242,6 +244,7 @@ const InquiryFormPage = () => {
     }
 
     clearDraftState();
+    appliedEditRef.current = true;
   }, [
     isEdit,
     editDetail,

--- a/src/types/inquiry/inquiryApi.type.ts
+++ b/src/types/inquiry/inquiryApi.type.ts
@@ -16,6 +16,7 @@ export interface PutInquiryRequest {
   content: string;
   assignee_ids: number[];
   observer_ids: number[];
+  file_ids: number[];
 }
 
 export interface PutInquiryResponse {


### PR DESCRIPTION

### 🔥 작업 내용
다음은 임시저장 로직 흐름입니다..
- 문의 작성 글에서 팀 선택 시
  - useCheckDraftExists 호출 → 해당 팀의 임시저장 존재 여부 확인
  - isExistsSuccess && !isLoading && !isFetching 상태에서만 자동 모달 오픈 판단
    - is_present: true → 모달 열림(detect 모드)  
    - is_present: false → 아무 동작 없음

- 임시저장 버튼 클릭 시 (handleClickTempSave)
  - 최신 서버 상태 재조회 (refetchDraftExists)
  - 서버 초안 없음
    → 필드 검증 통과 시 POST → draftId 저장 + 활성화 상태 전환
  - 서버 초안 있음 + 활성화 전 → 모달(conflict 모드) 노출

- 서버 초안 있음 + 활성화 후
    → PUT으로 현재 내용 업데이트

모달 액션
- 불러오기(restore)
  → 서버 초안 GET → 제목/본문/담당자/참조자/파일/조직 상태 세팅
  → 이후부터 PUT 고정

- 현재 글 유지(reset)
  → 모달 닫기 + 자동 재오픈 억제 플래그 설정

- 현재 글로 교체 저장(saveCurrentAsDraftReplacingExisting)
  → 기존 초안 DELETE → POST

---
### 🔗 관련 이슈 (선택)

- #87 
