### PR TITLE
[Fix] 등록보류 상태에서 문의자 버튼 변경

### DIFF
--- a/src/apis/inquiry/detail/inquiryManagementApi.ts
+++ b/src/apis/inquiry/detail/inquiryManagementApi.ts
@@ -5,6 +5,7 @@ import {
 } from "@/types/common/apiResponse.type";
 import {
   GetLastSentMailTimeResponse,
+  PatchInquiryReassignRequest,
   PutInquiryAssigneeRequest,
   PutInquiryObserverRequest,
 } from "@/types/inquiry/inquiryManagementApi.type";
@@ -35,6 +36,32 @@ export const putInquiryObserver = async (
   const response = await instance.patch<GlobalResponse<NoResponse>>(
     `/api/teams/${team_id}/inquiries/${inquiry_id}/change-observer`,
     data
+  );
+  return response.data;
+};
+
+// PATCH /api/teams/{team_id}/inquiries/{inquiry_id}/reassign
+// 등록 보류된 문의글 담당자 재할당
+export const patchInquiryReassign = async (
+  team_id: number,
+  inquiry_id: number,
+  data: PatchInquiryReassignRequest
+): ApiResponse<NoResponse> => {
+  const response = await instance.patch<GlobalResponse<NoResponse>>(
+    `/api/teams/${team_id}/inquiries/${inquiry_id}/reassign`,
+    data
+  );
+  return response.data;
+};
+
+// PATCH /api/teams/{team_id}/inquiries/{inquiry_id}/re-register
+// 등록 보류된 문의글 재등록
+export const patchInquiryReRegister = async (
+  team_id: number,
+  inquiry_id: number
+): ApiResponse<NoResponse> => {
+  const response = await instance.patch<GlobalResponse<NoResponse>>(
+    `/api/teams/${team_id}/inquiries/${inquiry_id}/re-register`
   );
   return response.data;
 };

--- a/src/components/inquiry/detail/AssigneeActions.tsx
+++ b/src/components/inquiry/detail/AssigneeActions.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import Close from "@/assets/svgs/inquiry/close.svg";
 import Check from "@/assets/svgs/inquiry/detail/check.svg";
 import Pencil from "@/assets/svgs/inquiry/detail/pencil.svg";
 import Users from "@/assets/svgs/inquiry/detail/users.svg";
@@ -17,10 +18,117 @@ const AssigneeActions = ({
   isEditingAssignees,
   onStartEditAssignees,
   onCompleteEditAssignees,
+  // 등록 보류 상태 관련 props
+  isPendingState = false,
+  isWriter = false,
+  isAssigneeChanged = false,
+  onCancelRegistration,
+  onSubmitInquiry,
 }: AssigneeActionsProps) => {
   const [isAssigneeModalOpen, setIsAssigneeModalOpen] = useState(false);
   const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false);
 
+  // 등록 보류 상태에서 문의자인 경우
+  if (isPendingState && isWriter) {
+    const openAssigneeModal = () => setIsAssigneeModalOpen(true);
+    const closeAssigneeModal = () => setIsAssigneeModalOpen(false);
+
+    const handleModalEditClick = () => {
+      closeAssigneeModal();
+      onStartEditAssignees?.();
+    };
+
+    const handleCompleteEditClick = () => {
+      setIsCompleteModalOpen(true);
+    };
+
+    const confirmCompleteEdit = () => {
+      setIsCompleteModalOpen(false);
+      onCompleteEditAssignees?.();
+    };
+
+    const cancelCompleteEdit = () => {
+      setIsCompleteModalOpen(false);
+    };
+
+    return (
+      <>
+        <div className="flex justify-between items-center w-full">
+          <div className="flex gap-8 items-center">
+            <Button
+              buttonType={isEditingAssignees ? "blue" : "default"}
+              className={isEditingAssignees ? "text-white" : "text-gray-80"}
+              onClick={
+                isEditingAssignees ? handleCompleteEditClick : openAssigneeModal
+              }
+            >
+              <Users
+                className={isEditingAssignees ? "text-white" : "text-gray-80"}
+              />
+              {isEditingAssignees ? "담당자 수정 완료" : "담당자 수정"}
+            </Button>
+          </div>
+
+          <div className="flex items-center gap-[16px]">
+            {/* 등록 취소 버튼 */}
+            <Button
+              buttonType="white"
+              onClick={onCancelRegistration}
+              className="text-gray-80"
+            >
+              <Close className="h-[20px] w-[20px] text-gray-80" />
+              <span>등록 취소</span>
+            </Button>
+            {/* 문의 등록하기 버튼 */}
+            <Button
+              buttonType={isAssigneeChanged ? "blue" : "done"}
+              onClick={isAssigneeChanged ? onSubmitInquiry : undefined}
+              disabled={!isAssigneeChanged}
+              className={
+                isAssigneeChanged
+                  ? "text-white"
+                  : "pointer-events-none text-gray-80"
+              }
+            >
+              <Pencil
+                className={
+                  isAssigneeChanged
+                    ? "h-[16px] w-[16px] text-white"
+                    : "h-[16px] w-[16px] text-gray-80"
+                }
+              />
+              <span>문의 등록하기</span>
+            </Button>
+          </div>
+        </div>
+
+        {/* 담당자 수정 모달 */}
+        <Modal
+          isOpen={isAssigneeModalOpen}
+          onClose={closeAssigneeModal}
+          title={`담당자/참조자를 \n수정하시겠습니까?`}
+          description={`담당자/참조자를 수정 시 권한을 부여하거나\n삭제할 수 있습니다.`}
+          buttons={[
+            { label: "뒤로가기", type: "gray", onClick: closeAssigneeModal },
+            { label: "수정하기", type: "blue", onClick: handleModalEditClick },
+          ]}
+        />
+        {/* 수정 완료 확인 모달 */}
+        <Modal
+          isOpen={isCompleteModalOpen}
+          onClose={cancelCompleteEdit}
+          title={`해당 내용으로 담당자/참조자 변경을\n완료하시겠습니까?`}
+          description={`해당 내용으로 담당자/참조자를 수정 시 권한을 부여하거나\n삭제할 수 있습니다.`}
+          buttons={[
+            { label: "뒤로가기", type: "gray", onClick: cancelCompleteEdit },
+            { label: "완료하기", type: "blue", onClick: confirmCompleteEdit },
+          ]}
+        />
+      </>
+    );
+  }
+
+  // 기존 로직 (등록 보류가 아니거나 문의자가 아닌 경우)
   if (!showAssigneeFeatures) return null;
 
   const shouldShowAnswerButton =
@@ -31,7 +139,7 @@ const AssigneeActions = ({
 
   const handleModalEditClick = () => {
     closeAssigneeModal();
-    onStartEditAssignees?.(); // 옵셔널 체이닝 사용
+    onStartEditAssignees?.();
   };
 
   const handleCompleteEditClick = () => {

--- a/src/components/inquiry/detail/AssigneeSection.tsx
+++ b/src/components/inquiry/detail/AssigneeSection.tsx
@@ -12,10 +12,6 @@ import DepartmentSelector from "@/components/inquiry/form/DepartmentSelector";
 import UserSearchList from "@/components/inquiry/form/UserSearchList";
 import { useDebounce } from "@/hooks/common/useDebounce";
 import { useOutsideClick } from "@/hooks/common/useOutsideClick";
-import {
-  filterAndSortCandidates,
-  pickActiveUsersSorted,
-} from "@/utils/userOrgUtils";
 import { AssigneeSectionProps } from "@/types/inquiryTypes";
 import { AssigneeUser } from "@/types/team/user.type";
 
@@ -76,33 +72,42 @@ const AssigneeSection = ({
   });
 
   // 선택된 담당자 목록
-  const selectedUsers = useMemo(
-    () => pickActiveUsersSorted(allUsers, tempAssigneeIds),
-    [allUsers, tempAssigneeIds]
-  );
-  const selectedObservers = useMemo(
-    () => pickActiveUsersSorted(allUsers, tempObserverIds),
-    [allUsers, tempObserverIds]
-  );
+  const selectedUsers = useMemo(() => {
+    if (!tempAssigneeIds) return [];
+    return allUsers.filter(user => tempAssigneeIds.includes(user.user_id));
+  }, [allUsers, tempAssigneeIds]);
 
-  // 드롭다운 후보
-  const filteredAssigneeUsers = useMemo(
-    () =>
-      filterAndSortCandidates(allUsers, {
-        excludeIds: [...tempAssigneeIds, ...tempObserverIds],
-        term: debouncedAssigneeInput,
-      }),
-    [allUsers, tempAssigneeIds, tempObserverIds, debouncedAssigneeInput]
-  );
+  // 선택된 참조자 목록
+  const selectedObservers = useMemo(() => {
+    if (!tempObserverIds) return [];
+    return allUsers.filter(user => tempObserverIds.includes(user.user_id));
+  }, [allUsers, tempObserverIds]);
 
-  const filteredObserverUsers = useMemo(
-    () =>
-      filterAndSortCandidates(allUsers, {
-        excludeIds: [...tempAssigneeIds, ...tempObserverIds],
-        term: debouncedObserverInput,
-      }),
-    [allUsers, tempAssigneeIds, tempObserverIds, debouncedObserverInput]
-  );
+  // 담당자용 필터링된 사용자 목록
+  const filteredAssigneeUsers = allUsers
+    .filter(u =>
+      u.username
+        ?.toLowerCase()
+        .includes(debouncedAssigneeInput.trim().toLowerCase())
+    )
+    .filter(
+      u =>
+        !tempAssigneeIds?.includes(u.user_id) &&
+        !tempObserverIds?.includes(u.user_id)
+    );
+
+  // 참조자용 필터링된 사용자 목록
+  const filteredObserverUsers = allUsers
+    .filter(u =>
+      u.username
+        ?.toLowerCase()
+        .includes(debouncedObserverInput.trim().toLowerCase())
+    )
+    .filter(
+      u =>
+        !tempAssigneeIds?.includes(u.user_id) &&
+        !tempObserverIds?.includes(u.user_id)
+    );
 
   // 담당자 선택 처리
   const handleSelectUser = (user: AssigneeUser) => {

--- a/src/components/inquiry/detail/Header.tsx
+++ b/src/components/inquiry/detail/Header.tsx
@@ -52,7 +52,7 @@ const Header = ({
             onClick={onDelete}
             className="justify-start text-point-red text-body1 cursor-pointer"
           >
-            게시물 삭제
+            게시글 삭제
           </button>
         </div>
       )}

--- a/src/components/inquiry/detail/InquiryCard.tsx
+++ b/src/components/inquiry/detail/InquiryCard.tsx
@@ -6,6 +6,7 @@ import InquiryContent from "@/components/inquiry/detail/InquiryContent";
 import InquiryHeader from "@/components/inquiry/detail/InquiryHeader";
 import NotificationButton from "@/components/inquiry/detail/NotificationButton";
 import PendingActions from "@/components/inquiry/detail/PendingActions";
+import { useInquiryManagementApi } from "@/hooks/inquiry/useInquiryManagementApi";
 import { useTeamApi } from "@/hooks/team/useTeamApi";
 import { useInquiryState } from "@/hooks/useInquiryState";
 import { InquiryCardProps } from "@/types/inquiryTypes";
@@ -34,10 +35,15 @@ const InquiryCard = ({
   const [isEditingAssignees, setIsEditingAssignees] = useState(false);
   const [tempAssigneeIds, setTempAssigneeIds] = useState<number[]>([]);
   const [tempObserverIds, setTempObserverIds] = useState<number[]>([]);
+  const [hasAssigneeChanged, setHasAssigneeChanged] = useState(false); // 담당자 변경 여부를 별도로 추적
 
   const { useUsersQuery } = useTeamApi();
   const { data: usersData } = useUsersQuery();
   const allUsers: AssigneeUser[] = usersData?.result ?? [];
+
+  // 새로운 API 훅 사용
+  const { patchInquiryReassignMutation, patchInquiryReRegisterMutation } =
+    useInquiryManagementApi();
 
   const {
     permissions,
@@ -48,6 +54,9 @@ const InquiryCard = ({
     answersCount,
   } = useInquiryState(inquiry, userRole, currentUserId);
 
+  // 등록 보류 상태 여부
+  const isPendingState = finalStateLabel === "등록 보류";
+
   // 담당자 정렬 로직
   const sortedAssignees = useMemo(() => {
     if (!inquiry.assignees) return [];
@@ -56,14 +65,29 @@ const InquiryCard = ({
     });
   }, [inquiry.assignees]);
 
-  // 현재 유저 확인 상태
+  // 담당자 변경 감지: 기존 담당자와 새 담당자 목록의 교집합이 없는지 확인
+  const isAssigneeChanged = useMemo(() => {
+    // 등록 보류 상태가 아니면 항상 false
+    if (!isPendingState) return false;
+
+    // 편집 완료 후에만 저장된 상태 사용 (편집 중에는 항상 false)
+    if (isEditingAssignees) {
+      return false;
+    }
+
+    // 편집 완료 후에만 저장된 상태 사용
+    return hasAssigneeChanged;
+  }, [isPendingState, isEditingAssignees, hasAssigneeChanged]);
+
+  // 현재 유저 확인 상태 - currentUserId가 ProfileData 타입이므로 id 속성 사용
   const isCurrentUserConfirmed = !!inquiry.assignees.find(
-    assignee => assignee.user_id === currentUserId && assignee.is_checked
+    assignee => assignee.user_id === currentUserId?.id && assignee.is_checked
   );
 
   const showButtons =
     permissions.showAssigneeFeatures ||
-    (isWriter && !["답변 완료", "등록 보류"].includes(finalStateLabel));
+    (isWriter && !["답변 완료", "등록 보류"].includes(finalStateLabel)) ||
+    (isPendingState && isWriter); // 등록 보류 상태에서 문의자인 경우 버튼 표시
 
   // 담당자 수정 모드 시작 (모달에서 수정하기 클릭 시)
   const handleStartEditAssignees = () => {
@@ -71,6 +95,7 @@ const InquiryCard = ({
     setTempAssigneeIds(inquiry.assignees.map(a => a.user_id));
     setTempObserverIds(inquiry.observers.map(o => o.userId));
     setIsEditingAssignees(true);
+    setHasAssigneeChanged(false); // 편집 시작할 때 변경 상태 초기화
   };
 
   // 담당자/참조자 수정 완료 처리
@@ -79,31 +104,68 @@ const InquiryCard = ({
       const originalAssigneeIds = inquiry.assignees.map(a => a.user_id);
       const originalObserverIds = inquiry.observers.map(o => o.userId);
 
+      // 담당자 변경 여부 확인 및 저장
+      const assigneeChanged =
+        JSON.stringify(originalAssigneeIds.sort()) !==
+        JSON.stringify(tempAssigneeIds.sort());
+      if (assigneeChanged) {
+        // 교집합 확인하여 실제 변경 조건에 맞는지 확인
+        const hasIntersection = originalAssigneeIds.some(id =>
+          tempAssigneeIds.includes(id)
+        );
+        const isValidChange = !hasIntersection && tempAssigneeIds.length > 0;
+        setHasAssigneeChanged(isValidChange);
+      }
+
       // 변경된 것만 API 호출
       const promises = [];
 
-      // 담당자가 변경된 경우
-      if (
-        JSON.stringify(originalAssigneeIds.sort()) !==
-        JSON.stringify(tempAssigneeIds.sort())
-      ) {
-        promises.push(
-          putInquiryAssignee(teamId, inquiry.inquiry_id, {
-            newAssignee_ids: tempAssigneeIds,
-          })
-        );
-      }
+      // 등록 보류 상태이면서 문의자인 경우 새로운 API 사용
+      if (isPendingState && isWriter) {
+        // 담당자가 변경된 경우 - 새로운 reassign API 사용
+        if (assigneeChanged) {
+          promises.push(
+            patchInquiryReassignMutation.mutateAsync({
+              team_id: teamId,
+              inquiry_id: inquiry.inquiry_id,
+              data: { newAssignee_ids: tempAssigneeIds },
+            })
+          );
+        }
 
-      // 참조자가 변경된 경우
-      if (
-        JSON.stringify(originalObserverIds.sort()) !==
-        JSON.stringify(tempObserverIds.sort())
-      ) {
-        promises.push(
-          putInquiryObserver(teamId, inquiry.inquiry_id, {
-            newObserver_ids: tempObserverIds,
-          })
-        );
+        // 참조자가 변경된 경우 - 기존 API 사용
+        if (
+          JSON.stringify(originalObserverIds.sort()) !==
+          JSON.stringify(tempObserverIds.sort())
+        ) {
+          promises.push(
+            putInquiryObserver(teamId, inquiry.inquiry_id, {
+              newObserver_ids: tempObserverIds,
+            })
+          );
+        }
+      } else {
+        // 기존 로직 - 기존 API 사용
+        // 담당자가 변경된 경우
+        if (assigneeChanged) {
+          promises.push(
+            putInquiryAssignee(teamId, inquiry.inquiry_id, {
+              newAssignee_ids: tempAssigneeIds,
+            })
+          );
+        }
+
+        // 참조자가 변경된 경우
+        if (
+          JSON.stringify(originalObserverIds.sort()) !==
+          JSON.stringify(tempObserverIds.sort())
+        ) {
+          promises.push(
+            putInquiryObserver(teamId, inquiry.inquiry_id, {
+              newObserver_ids: tempObserverIds,
+            })
+          );
+        }
       }
 
       if (promises.length > 0) {
@@ -114,11 +176,31 @@ const InquiryCard = ({
       setIsEditingAssignees(false);
       setTempAssigneeIds([]);
       setTempObserverIds([]);
-
-      // 페이지 새로고침
-      window.location.reload();
+      // hasAssigneeChanged는 유지하여 "문의 등록하기" 버튼 활성화 상태 보존
     } catch (error) {
       console.error("담당자/참조자 수정 실패:", error);
+      // 에러 메시지 표시
+      alert("담당자/참조자 수정에 실패했습니다. 다시 시도해주세요.");
+    }
+  };
+
+  // 등록 취소 처리 (문의글 삭제)
+  const handleCancelRegistration = () => {
+    handleDeleteInquiry();
+  };
+
+  // 문의 등록하기 처리
+  const handleSubmitInquiry = async () => {
+    try {
+      await patchInquiryReRegisterMutation.mutateAsync({
+        team_id: teamId,
+        inquiry_id: inquiry.inquiry_id,
+      });
+      // 성공 시 변경 상태 초기화
+      setHasAssigneeChanged(false);
+    } catch (error) {
+      console.error("문의 재등록 실패:", error);
+      // 에러는 mutation에서 처리됨
     }
   };
 
@@ -142,6 +224,7 @@ const InquiryCard = ({
         isAdmin={isAdmin}
         answersCount={answersCount}
         onDelete={handleDeleteInquiry}
+        isPendingState={isPendingState} // 등록 보류 상태 전달
       />
       <div className="self-stretch h-0 border-t border-gray-10" />
       <AssigneeSection
@@ -154,10 +237,33 @@ const InquiryCard = ({
         onObserverChange={setTempObserverIds}
         tempAssigneeIds={tempAssigneeIds}
         tempObserverIds={tempObserverIds}
-        currentUserId={currentUserId}
+        currentUserId={currentUserId?.id} // ProfileData의 id 속성 사용
+        isWriter={isWriter} // 문의자 여부 전달
       />
       {showButtons &&
-        (permissions.showAssigneeFeatures ? (
+        (isPendingState && isWriter ? (
+          // 등록 보류 상태에서 문의자인 경우
+          <AssigneeActions
+            showAssigneeFeatures={false} // 기존 담당자 기능은 비활성화
+            onStartAnswer={handleStartAnswer}
+            onConfirm={onConfirm}
+            isCurrentUserConfirmed={isCurrentUserConfirmed}
+            showEditor={showEditor}
+            hasMyComment={!!myComment}
+            inquiryId={inquiry.inquiry_id}
+            teamId={teamId}
+            isEditingAssignees={isEditingAssignees}
+            onStartEditAssignees={handleStartEditAssignees}
+            onCompleteEditAssignees={handleCompleteEditAssignees}
+            // 등록 보류 상태 관련 props
+            isPendingState={isPendingState}
+            isWriter={isWriter}
+            isAssigneeChanged={isAssigneeChanged}
+            onCancelRegistration={handleCancelRegistration}
+            onSubmitInquiry={handleSubmitInquiry}
+          />
+        ) : permissions.showAssigneeFeatures ? (
+          // 기존 담당자 기능
           <AssigneeActions
             showAssigneeFeatures={permissions.showAssigneeFeatures}
             onStartAnswer={handleStartAnswer}
@@ -172,6 +278,7 @@ const InquiryCard = ({
             onCompleteEditAssignees={handleCompleteEditAssignees}
           />
         ) : (
+          // 문의자 알림 버튼
           <div className="w-full flex justify-between items-center">
             <div className="flex justify-start">
               <NotificationButton

--- a/src/components/inquiry/detail/InquiryContent.tsx
+++ b/src/components/inquiry/detail/InquiryContent.tsx
@@ -24,6 +24,7 @@ const InquiryContent = ({
   inquiryId,
   teamId,
   files,
+  isPendingState, // 추가: 등록 보류 상태 여부
 }: InquiryContentProps) => {
   const navigate = useNavigate();
   const [isWriterDeleteModalOpen, setIsWriterDeleteModalOpen] = useState(false);
@@ -116,8 +117,8 @@ const InquiryContent = ({
                 {author.team_name}
               </div>
             </div>
-            {/* 문의자 수정/삭제 버튼 */}
-            {isWriter && (
+            {/* 문의자 수정/삭제 버튼 - 등록 보류 상태에서는 숨김 */}
+            {isWriter && !isPendingState && (
               <div className="flex items-center gap-4">
                 <button
                   onClick={handleEdit}

--- a/src/hooks/inquiry/useInquiryManagementApi.ts
+++ b/src/hooks/inquiry/useInquiryManagementApi.ts
@@ -3,12 +3,15 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { GlobalResponse } from "@/types/common/apiResponse.type";
 import {
   GetLastSentMailTimeResponse,
+  PatchInquiryReassignRequest,
   PutInquiryAssigneeRequest,
 } from "@/types/inquiry/inquiryManagementApi.type";
 import { InquiryData } from "@/types/inquiryTypes";
 
 import {
   getLastSentMailTime,
+  patchInquiryReassign,
+  patchInquiryReRegister,
   postInquiryNotify,
   putInquiryAssignee,
   putInquiryNotificationSetting,
@@ -60,6 +63,45 @@ export const useInquiryManagementApi = () => {
       queryClient.invalidateQueries({
         queryKey: ["teamInquiry", variables.team_id, variables.inquiry_id],
       });
+    },
+  });
+
+  // 등록 보류된 문의글 담당자 재할당
+  const patchInquiryReassignMutation = useMutation({
+    mutationFn: ({
+      team_id,
+      inquiry_id,
+      data,
+    }: {
+      team_id: number;
+      inquiry_id: number;
+      data: PatchInquiryReassignRequest;
+    }) => patchInquiryReassign(team_id, inquiry_id, data),
+    onSuccess: (_, variables) => {
+      // 문의 상세 정보 다시 불러오기
+      queryClient.invalidateQueries({
+        queryKey: ["teamInquiry", variables.team_id, variables.inquiry_id],
+      });
+    },
+  });
+
+  // 등록 보류된 문의글 재등록
+  const patchInquiryReRegisterMutation = useMutation({
+    mutationFn: ({
+      team_id,
+      inquiry_id,
+    }: {
+      team_id: number;
+      inquiry_id: number;
+    }) => patchInquiryReRegister(team_id, inquiry_id),
+    onSuccess: () => {
+      // 성공 시 페이지 새로고침
+      window.location.reload();
+    },
+    onError: error => {
+      console.error("문의 재등록 실패:", error);
+      // 에러 메시지 표시 (토스트, 알럿 등)
+      alert("문의 재등록에 실패했습니다. 다시 시도해주세요.");
     },
   });
 
@@ -123,6 +165,8 @@ export const useInquiryManagementApi = () => {
 
   return {
     putInquiryAssigneeMutation,
+    patchInquiryReassignMutation,
+    patchInquiryReRegisterMutation,
     postInquiryNotifyMutation,
     putInquiryNotificationMutation,
   };

--- a/src/hooks/useInquiryDetail.ts
+++ b/src/hooks/useInquiryDetail.ts
@@ -418,6 +418,7 @@ export const useInquiryDetail = () => {
     error,
     inquiryData,
     currentUserId,
+    myProfile: myProfileResponse?.result,
     showEditor,
     tabsToDisplay,
     selectedUserId,

--- a/src/hooks/useInquiryState.ts
+++ b/src/hooks/useInquiryState.ts
@@ -6,16 +6,19 @@ import {
 } from "@/constants/inquiryStates";
 import { USER_ROLE_PERMISSIONS } from "@/constants/userRoles";
 import { InquiryData, UserRole } from "@/types/inquiryTypes";
+import { ProfileData } from "@/types/profile/profile.type";
 
 export const useInquiryState = (
   inquiry: InquiryData,
   userRole: UserRole,
-  currentUserId?: number
+  currentUserId?: ProfileData | null
 ) => {
   const permissions =
     USER_ROLE_PERMISSIONS[userRole] || USER_ROLE_PERMISSIONS["default"];
-  const isWriter = inquiry.author.user_id === currentUserId;
-  const isAdmin = inquiry.team_role === "TEAM_LEADER";
+  const isWriter = inquiry.author.user_id === currentUserId?.id;
+  const isAdmin =
+    inquiry.team_role === "TEAM_LEADER" &&
+    inquiry.team.team_id === currentUserId?.team_id;
 
   const initialMappedState = (STATUS_MAPPING[inquiry.status] ||
     "BEFORE_CONFIRM") as InquiryState;

--- a/src/pages/inquiryDetail/InquiryDetailPage.tsx
+++ b/src/pages/inquiryDetail/InquiryDetailPage.tsx
@@ -120,7 +120,10 @@ const InquiryDetailPage = () => {
   };
 
   const userRole = (inquiryData.role?.toLowerCase() || "default") as UserRole;
-  const isAdmin = inquiryData.team_role === "TEAM_LEADER";
+  // 수정된 isAdmin 로직: 팀 리더이면서 "같은 팀"인 경우에만 true
+  const isAdmin =
+    inquiryData.team_role === "TEAM_LEADER" &&
+    myProfile?.team_id === inquiryData.team.team_id;
 
   return (
     <div className="min-h-screen bg-gray-5">

--- a/src/pages/inquiryDetail/InquiryDetailPage.tsx
+++ b/src/pages/inquiryDetail/InquiryDetailPage.tsx
@@ -20,6 +20,7 @@ const InquiryDetailPage = () => {
     isError,
     inquiryData,
     currentUserId,
+    myProfile,
     showEditor,
     tabsToDisplay,
     selectedUserId,
@@ -135,7 +136,7 @@ const InquiryDetailPage = () => {
             inquiry={inquiryData}
             teamId={Number(team_id)}
             userRole={userRole}
-            currentUserId={currentUserId}
+            currentUserId={myProfile}
             handleStartAnswer={handleStartAnswer}
             onConfirm={handleConfirm}
             handleDeleteInquiry={handleDeleteInquiry}

--- a/src/types/inquiry/inquiryManagementApi.type.ts
+++ b/src/types/inquiry/inquiryManagementApi.type.ts
@@ -13,6 +13,14 @@ export interface PutInquiryObserverRequest {
 }
 
 /**
+ * PATCH /api/teams/{team_id}/inquiries/{inquiry_id}/reassign
+ * 등록 보류된 문의글 담당자 재할당
+ */
+export interface PatchInquiryReassignRequest {
+  newAssignee_ids: number[];
+}
+
+/**
  * GET /api/inquiries/{inquiry_id}/mails/last-sent-time (마지막 메일 전송시간 조회)
  */
 export interface GetLastSentMailTimeResponse {

--- a/src/types/inquiryTypes.ts
+++ b/src/types/inquiryTypes.ts
@@ -1,5 +1,6 @@
+import { ProfileData } from "@/types/profile/profile.type";
+
 import { InquiryFile, UploadFile } from "./file/file.type";
-import { ProfileData } from "./profile/profile.type";
 export type UserRole = "default" | "assignee" | "writer" | "admin";
 
 // 답변 타입

--- a/src/types/inquiryTypes.ts
+++ b/src/types/inquiryTypes.ts
@@ -1,5 +1,5 @@
 import { InquiryFile, UploadFile } from "./file/file.type";
-
+import { ProfileData } from "./profile/profile.type";
 export type UserRole = "default" | "assignee" | "writer" | "admin";
 
 // 답변 타입
@@ -73,6 +73,7 @@ export interface InquiryContentProps {
   inquiryId: number;
   teamId: number;
   onDelete: () => void;
+  isPendingState?: boolean; // 추가: 등록 보류 상태 여부
 }
 
 // InquiryHeader Props 타입
@@ -102,6 +103,15 @@ export interface PendingActionsProps {
   isPendingState: boolean;
 }
 
+// 등록 보류 상태 문의자 액션 Props 타입 (새로 추가)
+export interface PendingWriterActionsProps {
+  isWriter: boolean;
+  isPendingState: boolean;
+  isAssigneeChanged: boolean; // 담당자가 변경되었는지 여부
+  onCancelRegistration: () => void; // 등록 취소
+  onSubmitInquiry: () => void; // 문의 등록하기
+}
+
 // AssigneeSection Props 타입
 export interface AssigneeSectionProps {
   assignees?: Array<{
@@ -128,6 +138,7 @@ export interface AssigneeSectionProps {
   tempAssigneeIds?: number[];
   tempObserverIds?: number[];
   currentUserId?: number;
+  isWriter?: boolean; // 추가: 문의자 여부
 }
 
 // AssigneeActionsProps 타입
@@ -143,6 +154,12 @@ export interface AssigneeActionsProps {
   isEditingAssignees?: boolean;
   onStartEditAssignees?: () => void;
   onCompleteEditAssignees?: () => void;
+  // 등록 보류 상태 관련 props 추가
+  isPendingState?: boolean;
+  isWriter?: boolean;
+  isAssigneeChanged?: boolean;
+  onCancelRegistration?: () => void;
+  onSubmitInquiry?: () => void;
 }
 
 // 통합된 문의 타입
@@ -215,7 +232,7 @@ export interface InquiryCardProps {
   inquiry: InquiryData;
   teamId: number;
   userRole?: UserRole;
-  currentUserId?: number;
+  currentUserId?: ProfileData | null;
   handleStartAnswer: (commentToEdit?: Comment) => void;
   onConfirm: () => void;
   handleDeleteInquiry: () => void;

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -58,15 +58,21 @@ export const formatDateToKorean = (
   let date: Date;
 
   if (typeof dateString === "string") {
-    const normalized = dateString.split(".")[0] + "Z";
-    date = new Date(normalized);
+    // formatTime과 동일한 방식으로 단순하게 파싱
+    // 브라우저가 자동으로 로컬 시간대 처리
+    date = new Date(dateString);
   } else {
     date = dateString;
   }
 
+  // 유효하지 않은 날짜 체크
+  if (isNaN(date.getTime())) {
+    console.warn("Invalid date:", dateString);
+    return "";
+  }
+
   if (options.showTime) {
     return date.toLocaleString("ko-KR", {
-      timeZone: "Asia/Seoul",
       year: "numeric",
       month: "long",
       day: "numeric",
@@ -77,7 +83,6 @@ export const formatDateToKorean = (
   }
 
   return date.toLocaleDateString("ko-KR", {
-    timeZone: "Asia/Seoul",
     year: "numeric",
     month: "long",
     day: "numeric",
@@ -94,8 +99,15 @@ export const formatRemain = (ms: number) => {
 
 export const parseUtc = (s?: string | null) => {
   if (!s) return null;
-  const hasTZ = /Z|[+-]\d\d:?\d\d$/.test(s);
-  const norm = hasTZ ? s : s.split(".")[0] + "Z";
-  const d = new Date(norm);
-  return isNaN(+d) ? null : d;
+
+  // formatTime, formatDateToKorean과 동일한 방식으로 단순 파싱
+  // 브라우저가 자동으로 로컬 시간대 처리하도록 함
+  const d = new Date(s);
+
+  if (isNaN(+d)) {
+    console.warn("Failed to parse date:", s);
+    return null;
+  }
+
+  return d;
 };


### PR DESCRIPTION
### 💡 To Reviewers

- 문의글 상세 페이지 - 등록보류  상태시 버튼 변경  (~~문의글 수정,삭제~~ → **담당자 수정, 등록 취소, 문의 등록하기**) ⇒ 주완
- 문의글 상세 페이지 - 팀관리자 문의글 삭제버튼 수정 (게시’물’ 삭제 ⇒ 게시'글' 삭제)

---

### 🔥 작업 내용

- 문의글 상세 페이지 - 등록보류  상태시 버튼 변경  (~~문의글 수정,삭제~~ → **담당자 수정, 등록 취소, 문의 등록하기**) ⇒ 주완
- 문의글 상세 페이지 - 팀관리자 문의글 삭제버튼 수정 (게시’물’ 삭제 ⇒ 게시'글' 삭제)

---

### 🤔 추후 작업 예정

-팀관리자 -> 자기 팀만 삭제 할 수 있도록 수정 ⇒ 주완
-문의글 상세 페이지 - 담당자 수정 확인 버튼 클릭시 줄바뀜 오류 -> 삭제하거 (띄워쓰기) 나 로 뜸 ⇒ 주완
---

### 📸 작업 결과 (선택)

- 작업 결과를 보여주는 스크린샷이 있다면 첨부해주세요.

---

### 🔗 관련 이슈 (선택)

- #92 
