### PR TITLE
[Fix] 스크랩 이슈 해결

### DIFF
--- a/src/hooks/home/useHomeApi.ts
+++ b/src/hooks/home/useHomeApi.ts
@@ -16,7 +16,7 @@ import {
 // 1. 홈페이지 초기 진입 데이터 조회
 export const useHomeInitial = () => {
   return useQuery<GlobalResponse<GetHomeInitialResponse>>({
-    queryKey: ["home", "initial"],
+    queryKey: ["inquiries", "home", "initial"],
     queryFn: getHomeInitial,
   });
 };
@@ -24,7 +24,7 @@ export const useHomeInitial = () => {
 // 2. 미확인 답변 조회
 export const useUncheckedAnswer = (teamId: number, page: number = 1) => {
   return useQuery<GlobalResponse<GetUncheckedAnswerResponse>>({
-    queryKey: ["home", "unchecked-answer", teamId, page],
+    queryKey: ["inquiries", "home", "unchecked-answer", teamId, page],
     queryFn: () => getUncheckedAnswer(teamId, page),
     enabled: !!teamId,
   });
@@ -33,7 +33,7 @@ export const useUncheckedAnswer = (teamId: number, page: number = 1) => {
 // 3. 미확인 문의 조회
 export const useUncheckedInquiries = (teamId: number, page: number = 1) => {
   return useQuery<GlobalResponse<GetUncheckedInquiriesResponse>>({
-    queryKey: ["home", "unchecked-inquiries", teamId, page],
+    queryKey: ["inquiries", "home", "unchecked-inquiries", teamId, page],
     queryFn: () => getUncheckedInquiries(teamId, page),
     enabled: !!teamId,
   });

--- a/src/hooks/scrap/useScrapApi.ts
+++ b/src/hooks/scrap/useScrapApi.ts
@@ -25,15 +25,6 @@ type InquiriesResponseWithBase<T extends TInquiryBase = TInquiryBase> = {
 export const useScrapApi = () => {
   const queryClient = useQueryClient();
 
-  // 주어진 query key 캐시에서 특정 inquiry_id를 가진 항목을 찾아 반환
-  const findInquiryInCache = (
-    key: unknown[],
-    inquiryId: number
-  ): TInquiryBase | undefined => {
-    const data = queryClient.getQueryData<InquiriesResponseWithBase>(key);
-    return data?.inquiries.find(i => i.inquiry_id === inquiryId);
-  };
-
   // 모든 "inquiries" 관련 캐시에서 특정 inquiry의 is_scrapped 필드 값을 수정
   const updateScrapField = (inquiryId: number, isScrapped: boolean) => {
     const queries = queryClient
@@ -41,6 +32,7 @@ export const useScrapApi = () => {
       .findAll({ queryKey: ["inquiries"] }); // "inquiries"로 시작하는 모든 쿼리 키 (ex. 내 담당 문의, 스크랩 내역, 내가 쓴 문의)
 
     queries.forEach(q => {
+      if (q.queryKey.includes("scrap")) return;
       const data = queryClient.getQueryData<InquiriesResponseWithBase>(
         q.queryKey
       );
@@ -75,21 +67,6 @@ export const useScrapApi = () => {
 
       // 해당 항목의 is_scrapped = true 로 변경
       updateScrapField(inquiryId, true);
-
-      // 스크랩 목록(init)에 추가
-      const found = findInquiryInCache(
-        ["inquiries", "assigned", "init", 1],
-        inquiryId
-      );
-      if (found) {
-        queryClient.setQueryData<InquiriesResponseWithBase>(
-          ["inquiries", "scrap", "init", 1],
-          old => ({
-            ...old!,
-            inquiries: [found, ...(old?.inquiries ?? [])],
-          })
-        );
-      }
     },
 
     onError: () => {},
@@ -113,16 +90,6 @@ export const useScrapApi = () => {
 
       // 해당 항목의 is_scrapped = false 로 변경
       updateScrapField(inquiryId, false);
-
-      // 스크랩 목록(init)에서 제거
-      queryClient.setQueryData<InquiriesResponseWithBase>(
-        ["inquiries", "scrap", "init", 1],
-        old => ({
-          ...old!,
-          inquiries:
-            old?.inquiries.filter(item => item.inquiry_id !== inquiryId) ?? [],
-        })
-      );
     },
 
     onError: () => {},


### PR DESCRIPTION
### 🔥 작업 내용

- HomePage 에서 쿼리키에 "inquiries" 추가하여 스크랩 캐싱 문제 해결하였습니다. @Kuuuuu00 
- 스크랩 add, remove 로직에 캐시 생성 로직을 제거하여 처음 로그인 이후 다른 페이지에서 스크랩을 진행하고, 처음으로 스크랩 페이지 진입 시 캐싱되어 API 요청이 안 나가는 문제를 해결하였습니다.

### 🔗 관련 이슈 (선택)
#70 
