### PR TITLE
[Feat] 브라우저 이탈 모달 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,46 +1,9 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { RouterProvider } from "react-router-dom";
 
-import AssignedPage from "@/pages/assigned/AssignedPage";
-import HomePage from "@/pages/home/HomePage";
-import InquiryFormPage from "@/pages/inquiry/InquiryFormPage";
-import InquiryDetailPage from "@/pages/inquiryDetail/InquiryDetailPage";
-import LoginPage from "@/pages/login/LoginPage";
-import MyQuestionsPage from "@/pages/myQuestions/MyQuestionsPage";
-import NotFoundPage from "@/pages/notFound/NotFoundPage";
-import ScrapPage from "@/pages/scrap/ScrapPage";
-import SearchResultPage from "@/pages/searchResult/SearchResultPage";
-import TeamBoardPage from "@/pages/teamBoard/TeamBoardPage";
-import UserSpacePage from "@/pages/userSpace/UserSpacePage";
-import Layout from "@/components/layout/Layout";
-import RequireAuth from "@/components/router/RequireAuth";
+import { router } from "./router";
 
 const App = () => {
-  return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/login" element={<LoginPage />} />
-
-        <Route element={<RequireAuth />}>
-          <Route path="/" element={<Layout />}>
-            <Route index element={<HomePage />} />
-            <Route path="/assigned" element={<AssignedPage />} />
-            <Route path="/team/:team_id" element={<TeamBoardPage />} />
-            <Route path="/my-questions" element={<MyQuestionsPage />} />
-            <Route path="/inquiry/form" element={<InquiryFormPage />} />
-            <Route path="/scrap" element={<ScrapPage />} />
-            <Route path="/space/:userId" element={<UserSpacePage />} />
-            <Route
-              path="/teams/:team_id/inquiries/:inquiry_id"
-              element={<InquiryDetailPage />}
-            />
-            <Route path="/result" element={<SearchResultPage />} />
-          </Route>
-        </Route>
-
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
-    </BrowserRouter>
-  );
+  return <RouterProvider router={router} />;
 };
 
 export default App;

--- a/src/components/Followup/FollowupForm.tsx
+++ b/src/components/Followup/FollowupForm.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useRef, useState } from "react";
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 
 import { useParams } from "react-router-dom";
 
@@ -41,6 +41,14 @@ const FollowupForm = ({
   const isMutating =
     postFollowupsMutation.isPending || putFollowupsMutation.isPending;
 
+  const formId = useMemo(
+    () =>
+      followupId != null
+        ? `followup:${inquiryId}:edit:${followupId}`
+        : `followup:${inquiryId}:new`,
+    [inquiryId, followupId]
+  );
+
   const [selectedId, setSelectedId] = useState<number | null>(
     initialAssigneeId ?? null
   );
@@ -50,7 +58,6 @@ const FollowupForm = ({
   const selectedName = assignees.find(a => a.user_id === selectedId)?.user_name;
   const isCompleteEnabled = selectedId !== null && content.trim().length > 0;
 
-  // ====== 이탈 감지용 더티 브로드캐스트 ======
   const baselineRef = useRef({
     assigneeId: initialAssigneeId ?? null,
     content: initialContent ?? "",
@@ -60,14 +67,11 @@ const FollowupForm = ({
     (selectedId ?? null) !== baselineRef.current.assigneeId ||
     content !== baselineRef.current.content;
 
-  const formKey =
-    followupId != null
-      ? `followup:edit:${followupId}`
-      : `followup:new:${inquiryId}:${initialAssigneeId ?? "na"}`;
+  const formKey = formId;
 
   const emitDirty = (
     dirty: boolean,
-    reason: "open" | "change" | "submit" | "close" | "unmount"
+    reason: "open" | "change" | "submit" | "close" | "unmount" | "reset"
   ) => {
     window.dispatchEvent(
       new CustomEvent("followup:dirty", {
@@ -83,21 +87,37 @@ const FollowupForm = ({
     );
   };
 
-  // 폼 오픈/언마운트 브로드캐스트
   useEffect(() => {
     emitDirty(isDirty, "open");
     return () => {
       emitDirty(false, "unmount");
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // 내용/담당자 변경 시 더티 상태 브로드캐스트
+  useEffect(() => {
+    setSelectedId(initialAssigneeId ?? null);
+    setContent(initialContent ?? "");
+
+    baselineRef.current = {
+      assigneeId: initialAssigneeId ?? null,
+      content: initialContent ?? "",
+    };
+
+    emitDirty(false, "reset");
+
+    queueMicrotask(() => {
+      if (textareaRef.current) {
+        const el = textareaRef.current;
+        el.style.height = "auto";
+        el.style.height = el.scrollHeight + "px";
+      }
+    });
+  }, [formId, initialAssigneeId, initialContent]);
+
   useEffect(() => {
     emitDirty(isDirty, "change");
   }, [isDirty]);
 
-  // 텍스트영역 오토리사이즈
   useEffect(() => {
     if (textareaRef.current) {
       const el = textareaRef.current;

--- a/src/components/Followup/FollowupForm.tsx
+++ b/src/components/Followup/FollowupForm.tsx
@@ -12,11 +12,12 @@ import Button from "../common/Button";
 type Props = {
   inquiryId: number;
   assignees: Assignee[];
-  // 수정시
   followupId?: number;
   initialContent?: string;
   initialAssigneeId?: number;
   onClose: () => void;
+  onSubmitSuccess?: () => void;
+  onSubmittedClose?: () => void;
 };
 
 const FollowupForm = ({
@@ -26,6 +27,8 @@ const FollowupForm = ({
   initialContent,
   initialAssigneeId,
   onClose,
+  onSubmitSuccess,
+  onSubmittedClose,
 }: Props) => {
   const { team_id } = useParams<{ team_id: string }>();
   const teamIdForKey = Number(team_id);
@@ -37,6 +40,7 @@ const FollowupForm = ({
 
   const isMutating =
     postFollowupsMutation.isPending || putFollowupsMutation.isPending;
+
   const [selectedId, setSelectedId] = useState<number | null>(
     initialAssigneeId ?? null
   );
@@ -44,14 +48,61 @@ const FollowupForm = ({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const selectedName = assignees.find(a => a.user_id === selectedId)?.user_name;
-
   const isCompleteEnabled = selectedId !== null && content.trim().length > 0;
 
+  // ====== 이탈 감지용 더티 브로드캐스트 ======
+  const baselineRef = useRef({
+    assigneeId: initialAssigneeId ?? null,
+    content: initialContent ?? "",
+  });
+
+  const isDirty =
+    (selectedId ?? null) !== baselineRef.current.assigneeId ||
+    content !== baselineRef.current.content;
+
+  const formKey =
+    followupId != null
+      ? `followup:edit:${followupId}`
+      : `followup:new:${inquiryId}:${initialAssigneeId ?? "na"}`;
+
+  const emitDirty = (
+    dirty: boolean,
+    reason: "open" | "change" | "submit" | "close" | "unmount"
+  ) => {
+    window.dispatchEvent(
+      new CustomEvent("followup:dirty", {
+        detail: {
+          dirty,
+          reason,
+          key: formKey,
+          scope: followupId != null ? "edit" : "new",
+          inquiryId,
+          followupId: followupId ?? null,
+        },
+      })
+    );
+  };
+
+  // 폼 오픈/언마운트 브로드캐스트
+  useEffect(() => {
+    emitDirty(isDirty, "open");
+    return () => {
+      emitDirty(false, "unmount");
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 내용/담당자 변경 시 더티 상태 브로드캐스트
+  useEffect(() => {
+    emitDirty(isDirty, "change");
+  }, [isDirty]);
+
+  // 텍스트영역 오토리사이즈
   useEffect(() => {
     if (textareaRef.current) {
-      textareaRef.current.style.height = "auto";
-      textareaRef.current.style.height =
-        textareaRef.current.scrollHeight + "px";
+      const el = textareaRef.current;
+      el.style.height = "auto";
+      el.style.height = el.scrollHeight + "px";
     }
   }, [content, selectedId]);
 
@@ -68,7 +119,10 @@ const FollowupForm = ({
       } else {
         await postFollowupsMutation.mutateAsync(payload);
       }
-      onClose();
+      onSubmitSuccess?.();
+
+      emitDirty(false, "submit");
+      (onSubmittedClose ?? onClose)();
     } catch (error) {
       console.error("Failed to submit followup", error);
     }
@@ -76,16 +130,15 @@ const FollowupForm = ({
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setContent(e.target.value);
-
     if (textareaRef.current) {
-      textareaRef.current.style.height = "auto";
-      textareaRef.current.style.height =
-        textareaRef.current.scrollHeight + "px";
+      const el = textareaRef.current;
+      el.style.height = "auto";
+      el.style.height = el.scrollHeight + "px";
     }
   };
 
   return (
-    <div className="w-full rounded-[15px] p-8 border-3 border-main flex gap-8 ">
+    <div className="w-full rounded-[15px] p-8 border-3 border-main flex gap-8">
       <div className="flex-1 min-h-[150px] flex flex-col gap-8">
         <div className="flex gap-5 items-center">
           <span className="text-body2 text-gray-50">문의대상</span>
@@ -103,20 +156,14 @@ const FollowupForm = ({
             ))}
           </div>
         </div>
+
         <div>
           <span className="text-body2-b text-state-progress-02">
             {selectedName}
           </span>
           <textarea
             ref={textareaRef}
-            className="
-              flex-1
-              w-full 
-              focus:outline-none   
-              resize-none
-              text-body2
-              disabled:opacity-60
-            "
+            className="flex-1 w-full focus:outline-none resize-none text-body2 disabled:opacity-60"
             placeholder=""
             value={content}
             onChange={handleChange}

--- a/src/components/Followup/FollowupSection.tsx
+++ b/src/components/Followup/FollowupSection.tsx
@@ -1,157 +1,74 @@
-import { useEffect, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 
 import clsx from "clsx";
-import { useBlocker } from "react-router-dom";
 
 import FollowupForm from "@/components/Followup/FollowupForm";
 import FollowupHeader from "@/components/Followup/FollowupHeader";
 import FollowupThread from "@/components/Followup/FollowupThread";
 import InquiryLeaveModal from "@/components/inquiry/common/InquiryLeaveModal";
+import { useLeaveGuard } from "@/hooks/inquiry/useLeaveGuard";
 import { InquiryData } from "@/types/inquiryTypes";
 
 type Props = { inquiry: InquiryData };
-type PendingAction = "none" | "local-close" | "route" | "edit-close";
+type PendingAction = "none" | "local-close" | "edit-close";
 
 const FollowupSection = ({ inquiry }: Props) => {
   const [isChatOpen, setIsChatOpen] = useState(false);
+  const [, setPending] = useState<PendingAction>("none");
+  const [, setPendingEditId] = useState<number | null>(null);
+
   const hasFollowups = (inquiry.follow_ups?.count ?? 0) > 0;
   const hasGap = isChatOpen || hasFollowups;
 
-  const [isLeaveOpen, setIsLeaveOpen] = useState(false);
-  const [pending, setPending] = useState<PendingAction>("none");
-  const [pendingEditId, setPendingEditId] = useState<number | null>(null);
-  const blockerRef = useRef<ReturnType<typeof useBlocker> | null>(null);
+  const keyPrefix = useMemo(
+    () => `followup:${inquiry.inquiry_id}:`,
+    [inquiry.inquiry_id]
+  );
 
-  const dirtyKeysRef = useRef<Set<string>>(new Set());
-  const [, forceRender] = useState(0);
+  const snapshot = useMemo(
+    () => ({ inquiryId: inquiry.inquiry_id, isChatOpen }),
+    [inquiry.inquiry_id, isChatOpen]
+  );
 
-  // 제출로 인한 닫기는 가드 완전 우회
-  const bypassRef = useRef(false);
-
-  // ===== 더티 이벤트 구독 =====
-  useEffect(() => {
-    const onDirty = (e: Event) => {
-      const ce = e as CustomEvent<{ dirty: boolean; key?: string }>;
-      const key = ce.detail?.key;
-      if (!key) return;
-
-      const set = dirtyKeysRef.current;
-      let changed = false;
-
-      if (ce.detail?.dirty) {
-        if (!set.has(key)) {
-          set.add(key);
-          changed = true;
-        }
-      } else {
-        if (set.has(key)) {
-          set.delete(key);
-          changed = true;
-        }
-      }
-
-      if (changed) {
-        // size 변동 시에만 리렌더
-        forceRender(n => n + 1);
-      }
-    };
-
-    window.addEventListener("followup:dirty", onDirty);
-    return () => window.removeEventListener("followup:dirty", onDirty);
-  }, []);
-
-  // 가드 활성 조건: 로컬 폼 열림 or 외부(어디든) 더티, 그리고 우회 아님
-  const guardActive =
-    (isChatOpen || dirtyKeysRef.current.size > 0) && !bypassRef.current;
-
-  // 최신 가드 상태를 핸들러에서 읽기 위한 ref
-  const guardActiveRef = useRef(guardActive);
-  guardActiveRef.current = guardActive;
-
-  // 라우팅 이탈 차단
-  const blocker = useBlocker(guardActive);
-  blockerRef.current = blocker;
-
-  useEffect(() => {
-    if (blocker.state === "blocked" && !bypassRef.current) {
-      setPending("route");
-      setIsLeaveOpen(true);
-    }
-  }, [blocker.state]);
-
-  // beforeunload는 항상 1회 등록, 동작 여부만 ref로 제어
-  useEffect(() => {
-    const onBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (guardActiveRef.current) {
-        e.preventDefault();
-        e.returnValue = "";
-      }
-    };
-    window.addEventListener("beforeunload", onBeforeUnload);
-    return () => window.removeEventListener("beforeunload", onBeforeUnload);
-  }, []);
-
-  // ===== 편집 폼 닫기 요청(가드 경유) =====
-  const requestEditClose = (followupId: number) => {
-    const key = `followup:edit:${followupId}`;
-    const isDirty = dirtyKeysRef.current.has(key);
-
-    if (isDirty) {
-      setPendingEditId(followupId);
-      setPending("edit-close");
-      setIsLeaveOpen(true);
-    } else {
-      // 더티 아님 → 바로 닫기 이벤트
-      window.dispatchEvent(
-        new CustomEvent("followup:close-edit", { detail: { followupId } })
-      );
-    }
-  };
+  const { modalProps, tryLeave, runWithBypass } = useLeaveGuard(snapshot, {
+    enabled: true,
+    initializeClean: true,
+    beforeUnload: true,
+    eventPrefixes: [keyPrefix],
+    routerBlock: true,
+  });
 
   const requestLocalClose = () => {
-    if (!isChatOpen) {
-      setIsChatOpen(false);
-      return;
-    }
+    tryLeave(() => setIsChatOpen(false));
     setPending("local-close");
-    setIsLeaveOpen(true);
   };
 
   const handleToggleChat = () => {
     if (isChatOpen) {
       requestLocalClose();
     } else {
-      bypassRef.current = false;
       setIsChatOpen(true);
     }
   };
 
-  const handleConfirmLeave = () => {
-    setIsLeaveOpen(false);
-
-    if (pending === "route") {
-      blockerRef.current?.proceed?.();
-    } else if (pending === "local-close") {
-      setIsChatOpen(false);
-    } else if (pending === "edit-close" && pendingEditId != null) {
+  const requestEditClose = (followupId: number) => {
+    setPending("edit-close");
+    setPendingEditId(followupId);
+    tryLeave(() => {
       window.dispatchEvent(
         new CustomEvent("followup:close-edit", {
-          detail: { followupId: pendingEditId },
+          detail: { followupId },
         })
       );
       setPendingEditId(null);
-    }
-
-    setPending("none");
-    bypassRef.current = false;
+      setPending("none");
+    });
   };
 
-  const handleCancelLeave = () => {
-    setIsLeaveOpen(false);
-    if (pending === "route") blockerRef.current?.reset?.();
-    setPending("none");
-    setPendingEditId(null);
-    bypassRef.current = false;
+  const handleSubmittedClose = () => {
+    runWithBypass(() => {
+      setIsChatOpen(false);
+    });
   };
 
   return (
@@ -172,11 +89,14 @@ const FollowupSection = ({ inquiry }: Props) => {
           inquiryId={inquiry.inquiry_id}
           assignees={inquiry.assignees}
           onClose={requestLocalClose}
-          onSubmitSuccess={() => {}}
-          onSubmittedClose={() => {
-            bypassRef.current = true;
-            setIsChatOpen(false);
+          onSubmitSuccess={() => {
+            window.dispatchEvent(
+              new CustomEvent("followup:dirty", {
+                detail: { dirty: false, key: `${keyPrefix}new` },
+              })
+            );
           }}
+          onSubmittedClose={handleSubmittedClose}
         />
       )}
 
@@ -187,11 +107,7 @@ const FollowupSection = ({ inquiry }: Props) => {
         onRequestEditClose={requestEditClose}
       />
 
-      <InquiryLeaveModal
-        isOpen={isLeaveOpen}
-        onConfirm={handleConfirmLeave}
-        onCancel={handleCancelLeave}
-      />
+      <InquiryLeaveModal {...modalProps} />
     </div>
   );
 };

--- a/src/components/Followup/FollowupSection.tsx
+++ b/src/components/Followup/FollowupSection.tsx
@@ -1,23 +1,157 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import clsx from "clsx";
+import { useBlocker } from "react-router-dom";
 
 import FollowupForm from "@/components/Followup/FollowupForm";
 import FollowupHeader from "@/components/Followup/FollowupHeader";
 import FollowupThread from "@/components/Followup/FollowupThread";
+import InquiryLeaveModal from "@/components/inquiry/common/InquiryLeaveModal";
 import { InquiryData } from "@/types/inquiryTypes";
 
-type Props = {
-  inquiry: InquiryData;
-};
+type Props = { inquiry: InquiryData };
+type PendingAction = "none" | "local-close" | "route" | "edit-close";
 
 const FollowupSection = ({ inquiry }: Props) => {
   const [isChatOpen, setIsChatOpen] = useState(false);
   const hasFollowups = (inquiry.follow_ups?.count ?? 0) > 0;
   const hasGap = isChatOpen || hasFollowups;
 
+  const [isLeaveOpen, setIsLeaveOpen] = useState(false);
+  const [pending, setPending] = useState<PendingAction>("none");
+  const [pendingEditId, setPendingEditId] = useState<number | null>(null);
+  const blockerRef = useRef<ReturnType<typeof useBlocker> | null>(null);
+
+  const dirtyKeysRef = useRef<Set<string>>(new Set());
+  const [, forceRender] = useState(0);
+
+  // 제출로 인한 닫기는 가드 완전 우회
+  const bypassRef = useRef(false);
+
+  // ===== 더티 이벤트 구독 =====
+  useEffect(() => {
+    const onDirty = (e: Event) => {
+      const ce = e as CustomEvent<{ dirty: boolean; key?: string }>;
+      const key = ce.detail?.key;
+      if (!key) return;
+
+      const set = dirtyKeysRef.current;
+      let changed = false;
+
+      if (ce.detail?.dirty) {
+        if (!set.has(key)) {
+          set.add(key);
+          changed = true;
+        }
+      } else {
+        if (set.has(key)) {
+          set.delete(key);
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        // size 변동 시에만 리렌더
+        forceRender(n => n + 1);
+      }
+    };
+
+    window.addEventListener("followup:dirty", onDirty);
+    return () => window.removeEventListener("followup:dirty", onDirty);
+  }, []);
+
+  // 가드 활성 조건: 로컬 폼 열림 or 외부(어디든) 더티, 그리고 우회 아님
+  const guardActive =
+    (isChatOpen || dirtyKeysRef.current.size > 0) && !bypassRef.current;
+
+  // 최신 가드 상태를 핸들러에서 읽기 위한 ref
+  const guardActiveRef = useRef(guardActive);
+  guardActiveRef.current = guardActive;
+
+  // 라우팅 이탈 차단
+  const blocker = useBlocker(guardActive);
+  blockerRef.current = blocker;
+
+  useEffect(() => {
+    if (blocker.state === "blocked" && !bypassRef.current) {
+      setPending("route");
+      setIsLeaveOpen(true);
+    }
+  }, [blocker.state]);
+
+  // beforeunload는 항상 1회 등록, 동작 여부만 ref로 제어
+  useEffect(() => {
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (guardActiveRef.current) {
+        e.preventDefault();
+        e.returnValue = "";
+      }
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, []);
+
+  // ===== 편집 폼 닫기 요청(가드 경유) =====
+  const requestEditClose = (followupId: number) => {
+    const key = `followup:edit:${followupId}`;
+    const isDirty = dirtyKeysRef.current.has(key);
+
+    if (isDirty) {
+      setPendingEditId(followupId);
+      setPending("edit-close");
+      setIsLeaveOpen(true);
+    } else {
+      // 더티 아님 → 바로 닫기 이벤트
+      window.dispatchEvent(
+        new CustomEvent("followup:close-edit", { detail: { followupId } })
+      );
+    }
+  };
+
+  const requestLocalClose = () => {
+    if (!isChatOpen) {
+      setIsChatOpen(false);
+      return;
+    }
+    setPending("local-close");
+    setIsLeaveOpen(true);
+  };
+
   const handleToggleChat = () => {
-    setIsChatOpen(prev => !prev);
+    if (isChatOpen) {
+      requestLocalClose();
+    } else {
+      bypassRef.current = false;
+      setIsChatOpen(true);
+    }
+  };
+
+  const handleConfirmLeave = () => {
+    setIsLeaveOpen(false);
+
+    if (pending === "route") {
+      blockerRef.current?.proceed?.();
+    } else if (pending === "local-close") {
+      setIsChatOpen(false);
+    } else if (pending === "edit-close" && pendingEditId != null) {
+      window.dispatchEvent(
+        new CustomEvent("followup:close-edit", {
+          detail: { followupId: pendingEditId },
+        })
+      );
+      setPendingEditId(null);
+    }
+
+    setPending("none");
+    bypassRef.current = false;
+  };
+
+  const handleCancelLeave = () => {
+    setIsLeaveOpen(false);
+    if (pending === "route") blockerRef.current?.reset?.();
+    setPending("none");
+    setPendingEditId(null);
+    bypassRef.current = false;
   };
 
   return (
@@ -27,19 +161,22 @@ const FollowupSection = ({ inquiry }: Props) => {
         hasGap ? "gap-8" : "gap-0"
       )}
     >
-      {/* 헤더에 onClickNew prop으로 토글 함수 전달 */}
       <FollowupHeader
-        follow_ups_cnt={inquiry.follow_ups.count}
+        follow_ups_cnt={inquiry.follow_ups?.count ?? 0}
         isChatOpen={isChatOpen}
         onClick={handleToggleChat}
       />
 
-      {/* isChatOpen이 true일 때만 InquiryForm 렌더 */}
       {isChatOpen && (
         <FollowupForm
           inquiryId={inquiry.inquiry_id}
           assignees={inquiry.assignees}
-          onClose={handleToggleChat}
+          onClose={requestLocalClose}
+          onSubmitSuccess={() => {}}
+          onSubmittedClose={() => {
+            bypassRef.current = true;
+            setIsChatOpen(false);
+          }}
         />
       )}
 
@@ -47,6 +184,13 @@ const FollowupSection = ({ inquiry }: Props) => {
         inquiryId={inquiry.inquiry_id}
         assignees={inquiry.assignees}
         follow_ups={inquiry.follow_ups.follow_ups}
+        onRequestEditClose={requestEditClose}
+      />
+
+      <InquiryLeaveModal
+        isOpen={isLeaveOpen}
+        onConfirm={handleConfirmLeave}
+        onCancel={handleCancelLeave}
       />
     </div>
   );

--- a/src/components/Followup/FollowupThread.tsx
+++ b/src/components/Followup/FollowupThread.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Enter } from "@/assets/svgs/followup";
 import FollowUpBody from "@/components/Followup/FollowupBody";
 import FollowupCommentForm from "@/components/Followup/FollowupCommentForm";
-import FollowUpForm from "@/components/Followup/FollowupForm";
+import FollowupForm from "@/components/Followup/FollowupForm";
 import { Assignee, FollowUp } from "@/types/inquiryTypes";
 
 import { useProfileStore } from "@/store/useProfileStore";
@@ -12,9 +12,15 @@ type Props = {
   inquiryId: number;
   assignees: Assignee[];
   follow_ups: FollowUp[];
+  onRequestEditClose: (followupId: number) => void;
 };
 
-const FollowupThread = ({ inquiryId, assignees, follow_ups }: Props) => {
+const FollowupThread = ({
+  inquiryId,
+  assignees,
+  follow_ups,
+  onRequestEditClose,
+}: Props) => {
   const [replyTarget, setReplyTarget] = useState<{
     kind: "followup" | "comment";
     id: number;
@@ -23,6 +29,19 @@ const FollowupThread = ({ inquiryId, assignees, follow_ups }: Props) => {
   const [editCommentId, setEditCommentId] = useState<number | null>(null);
 
   const currentUserId = useProfileStore(state => state.profile?.id);
+
+  // 편집 닫기 확정 이벤트 수신 → 실제 닫기
+  useEffect(() => {
+    const onCloseEdit = (e: Event) => {
+      const ce = e as CustomEvent<{ followupId: number }>;
+      const id = ce.detail?.followupId;
+      if (id != null && editFollowUpId === id) {
+        setEditFollowUpId(null);
+      }
+    };
+    window.addEventListener("followup:close-edit", onCloseEdit);
+    return () => window.removeEventListener("followup:close-edit", onCloseEdit);
+  }, [editFollowUpId]);
 
   const handleAnswerOpen = (kind: "followup" | "comment", id: number) => {
     setReplyTarget(prev =>
@@ -39,9 +58,15 @@ const FollowupThread = ({ inquiryId, assignees, follow_ups }: Props) => {
   };
 
   const handleEditFollowUp = (followUpId: number) => {
-    setEditFollowUpId(prev => (prev === followUpId ? null : followUpId));
-    setReplyTarget(null);
-    setEditCommentId(null);
+    // 켜기
+    if (editFollowUpId !== followUpId) {
+      setEditFollowUpId(followUpId);
+      setReplyTarget(null);
+      setEditCommentId(null);
+      return;
+    }
+    // 끄기 → 가드 경유
+    onRequestEditClose(followUpId);
   };
 
   const handleEditComment = (commentId: number) => {
@@ -55,15 +80,20 @@ const FollowupThread = ({ inquiryId, assignees, follow_ups }: Props) => {
       {follow_ups?.map(fu => (
         <div
           key={fu.follow_up_id}
-          className="flex flex-col border-t border-gray-20 gap-8 pt-8 "
+          className="flex flex-col border-t border-gray-20 gap-8 pt-8"
         >
           {/* 추가문의(부모) */}
           {editFollowUpId === fu.follow_up_id ? (
-            <FollowUpForm
+            <FollowupForm
               inquiryId={inquiryId}
               followupId={fu.follow_up_id}
               assignees={assignees}
-              onClose={handleFormClose}
+              onClose={() => onRequestEditClose(fu.follow_up_id)} // 닫기 버튼도 가드 경유
+              onSubmitSuccess={() => {}}
+              onSubmittedClose={() => {
+                // 제출 성공 시 편집 종료
+                setEditFollowUpId(null);
+              }}
               initialContent={fu.content}
               initialAssigneeId={fu.tagged_user.user_id}
             />
@@ -73,9 +103,9 @@ const FollowupThread = ({ inquiryId, assignees, follow_ups }: Props) => {
               author={fu.author}
               created_at={fu.created_at}
               content={fu.content}
-              canEdit={fu.author.user_id === currentUserId} // 로그인 사용자만 수정 가능
+              canEdit={fu.author.user_id === currentUserId}
               onAnswer={() => handleAnswerOpen("followup", fu.follow_up_id)}
-              onEdit={() => handleEditFollowUp(fu.follow_up_id)}
+              onEdit={() => handleEditFollowUp(fu.follow_up_id)} // 토글 → 가드 경유
             />
           )}
 
@@ -89,50 +119,50 @@ const FollowupThread = ({ inquiryId, assignees, follow_ups }: Props) => {
               />
             )}
 
-          {/* 추가문의 댓글(하위) */}
-          {fu.comments &&
-            fu.comments.length > 0 &&
-            fu.comments.map(c => (
-              <div className="flex flex-col gap-8" key={c.comment_id}>
-                {editCommentId === c.comment_id ? (
-                  /* 추가문의 댓글(하위) 수정 */
-                  <FollowupCommentForm
-                    taggedUser={c.tagged_user}
-                    followUpId={fu.follow_up_id}
-                    commentId={c.comment_id}
-                    initialContent={c.content}
-                    onClose={handleFormClose}
-                  />
-                ) : (
-                  <div className="flex gap-4">
+          {fu.comments && fu.comments.length > 0 && (
+            <div className="px-6 py-2 bg-gray-10 rounded-[15px]">
+              <div className="flex flex-col">
+                {fu.comments.map(c => (
+                  <div key={c.comment_id} className="flex gap-4 py-8">
                     <Enter />
                     <div className="flex-1">
-                      <FollowUpBody
-                        taggedUser={c.tagged_user}
-                        author={c.author}
-                        created_at={c.created_at}
-                        content={c.content}
-                        canEdit={c.author.user_id === currentUserId} // 로그인 사용자만 수정 가능
-                        onAnswer={() =>
-                          handleAnswerOpen("comment", c.comment_id)
-                        }
-                        onEdit={() => handleEditComment(c.comment_id)}
-                      />
+                      {editCommentId === c.comment_id ? (
+                        <FollowupCommentForm
+                          taggedUser={c.tagged_user}
+                          followUpId={fu.follow_up_id}
+                          commentId={c.comment_id}
+                          initialContent={c.content}
+                          onClose={handleFormClose}
+                        />
+                      ) : (
+                        <FollowUpBody
+                          taggedUser={c.tagged_user}
+                          author={c.author}
+                          created_at={c.created_at}
+                          content={c.content}
+                          canEdit={c.author.user_id === currentUserId}
+                          onAnswer={() =>
+                            handleAnswerOpen("comment", c.comment_id)
+                          }
+                          onEdit={() => handleEditComment(c.comment_id)}
+                        />
+                      )}
                     </div>
                   </div>
-                )}
+                ))}
 
-                {/* 추가문의 댓글(하위) 입력 폼*/}
-                {replyTarget?.kind === "comment" &&
-                  replyTarget.id === c.comment_id && (
+                {replyTarget?.kind === "comment" && (
+                  <div className="mb-8">
                     <FollowupCommentForm
-                      taggedUser={c.author}
+                      taggedUser={fu.author}
                       followUpId={fu.follow_up_id}
                       onClose={handleFormClose}
                     />
-                  )}
+                  </div>
+                )}
               </div>
-            ))}
+            </div>
+          )}
         </div>
       ))}
     </div>

--- a/src/components/Followup/FollowupThread.tsx
+++ b/src/components/Followup/FollowupThread.tsx
@@ -37,11 +37,16 @@ const FollowupThread = ({
       const id = ce.detail?.followupId;
       if (id != null && editFollowUpId === id) {
         setEditFollowUpId(null);
+        window.dispatchEvent(
+          new CustomEvent("followup:dirty", {
+            detail: { dirty: false, key: `followup:${inquiryId}:edit:${id}` },
+          })
+        );
       }
     };
     window.addEventListener("followup:close-edit", onCloseEdit);
     return () => window.removeEventListener("followup:close-edit", onCloseEdit);
-  }, [editFollowUpId]);
+  }, [editFollowUpId, inquiryId]);
 
   const handleAnswerOpen = (kind: "followup" | "comment", id: number) => {
     setReplyTarget(prev =>
@@ -85,6 +90,7 @@ const FollowupThread = ({
           {/* 추가문의(부모) */}
           {editFollowUpId === fu.follow_up_id ? (
             <FollowupForm
+              key={`followup:${inquiryId}:edit:${fu.follow_up_id}`}
               inquiryId={inquiryId}
               followupId={fu.follow_up_id}
               assignees={assignees}

--- a/src/components/inquiry/common/InquiryLeaveModal.tsx
+++ b/src/components/inquiry/common/InquiryLeaveModal.tsx
@@ -1,0 +1,28 @@
+import Modal from "@/components/common/Modal";
+
+interface InquiryLeaveModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const InquiryLeaveModal = ({
+  isOpen,
+  onConfirm,
+  onCancel,
+}: InquiryLeaveModalProps) => {
+  return (
+    <Modal
+      title="페이지를 나가시겠습니까?"
+      description={`작성 중인 내용이 저장되지 않습니다. \n그래도 나가시겠습니까?`}
+      buttons={[
+        { label: "취소", type: "white", onClick: onCancel },
+        { label: "나가기", type: "blue", onClick: onConfirm },
+      ]}
+      isOpen={isOpen}
+      onClose={onCancel}
+    />
+  );
+};
+
+export default InquiryLeaveModal;

--- a/src/components/inquiry/detail/answer/AnswerEditor.tsx
+++ b/src/components/inquiry/detail/answer/AnswerEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import Pencil from "@/assets/svgs/inquiry/pencil.svg";
 import Button from "@/components/common/Button";
@@ -24,25 +24,71 @@ const AnswerEditor = ({
   const { editorRef, fileInputRef, activeSet, execCommand, handleFileChange } =
     useEditor();
 
-  // 초기 주입: 정규화 후 세팅
+  const keyRef = useRef<string>(
+    `answer:${mode}:${Date.now()}:${Math.random().toString(36).slice(2)}`
+  );
+  const answerKey = keyRef.current;
+
+  const baselineRef = useRef<string>("");
+
+  // 에디터 준비될 때까지 초기화 (RAF)
   useEffect(() => {
-    const instance = editorRef.current?.getInstance();
-    if (!instance) return;
-    const prepared = normalizeContent(initialContent ?? "");
-    if (instance.getMarkdown() !== prepared) {
-      instance.setMarkdown(prepared);
-    }
-  }, [initialContent, editorRef]);
+    let raf = 0;
+    let initialized = false;
 
-  // 변경 감지: 래퍼 prop 사용
+    const init = () => {
+      const instance = editorRef.current?.getInstance?.();
+      if (!instance) {
+        raf = requestAnimationFrame(init);
+        return;
+      }
+
+      const prepared = normalizeContent(initialContent ?? "");
+      if (instance.getMarkdown() !== prepared) {
+        instance.setMarkdown(prepared);
+      }
+
+      baselineRef.current = prepared;
+
+      const isDirty = (instance.getMarkdown() ?? "") !== baselineRef.current;
+      const evt = new CustomEvent("followup:dirty", {
+        detail: { dirty: isDirty, reason: "open", key: answerKey },
+      });
+      window.dispatchEvent(evt);
+
+      initialized = true;
+    };
+
+    init();
+
+    return () => {
+      if (!initialized) cancelAnimationFrame(raf);
+      window.dispatchEvent(
+        new CustomEvent("followup:dirty", {
+          detail: { dirty: false, reason: "unmount", key: answerKey },
+        })
+      );
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialContent]);
+
+  // 변경 즉시 더티 방송 (+ 같은 틱 경합 보강)
   const handleChange = useCallback(() => {
-    const md = editorRef.current?.getInstance().getMarkdown() ?? "";
+    const md = editorRef.current?.getInstance?.().getMarkdown?.() ?? "";
     onContentChange(md);
-  }, [editorRef, onContentChange]);
 
-  const handleSubmit = () => {
-    const raw = editorRef.current?.getInstance().getMarkdown() || "";
-    onSubmit(normalizeContent(raw), fileIds);
+    const isDirty = md !== baselineRef.current;
+    const evt = new CustomEvent("followup:dirty", {
+      detail: { dirty: isDirty, reason: "change", key: answerKey },
+    });
+    window.dispatchEvent(evt);
+    queueMicrotask(() => window.dispatchEvent(evt));
+  }, [editorRef, onContentChange, answerKey]);
+
+  const handleSubmit = async () => {
+    const raw = editorRef.current?.getInstance?.().getMarkdown?.() || "";
+    const normalized = normalizeContent(raw);
+    await onSubmit(normalized, fileIds);
   };
 
   const isEdit = mode === "edit";
@@ -72,12 +118,14 @@ const AnswerEditor = ({
           />
         </div>
       </div>
+
       <FileUploadBox
         fileIds={fileIds}
         files={files}
         setFileIds={setFileIds}
         setFiles={setFiles}
       />
+
       <div className="flex justify-end gap-4">
         <Button buttonType="blue" onClick={handleSubmit}>
           <Pencil />

--- a/src/components/inquiry/detail/answer/AnswerSection.tsx
+++ b/src/components/inquiry/detail/answer/AnswerSection.tsx
@@ -1,31 +1,19 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import clsx from "clsx";
 
+import InquiryLeaveModal from "@/components/inquiry/common/InquiryLeaveModal";
+import { useLeaveGuard } from "@/hooks/inquiry/useLeaveGuard";
+import {
+  buildFileSig,
+  mapServerFilesToUploadList,
+} from "@/utils/leaveModalUtils";
 import type { UploadFile } from "@/types/file/file.type";
 import type { AnswerSectionProps } from "@/types/inquiryTypes";
 
 import AnswerEditor from "./AnswerEditor";
 import AnswerItem from "./AnswerItem";
 import AnswerList from "./AnswerList";
-
-const mapServerFilesToUploadList = (
-  files: Array<{
-    file_id: number;
-    file_key: string;
-    file_name?: string;
-    file_size?: number;
-  }>
-): UploadFile[] =>
-  files.map(f => ({
-    id: f.file_id,
-    file_id: f.file_id,
-    file_name:
-      f.file_name ?? decodeURIComponent(f.file_key.split("/").pop() ?? "파일"),
-    file_size: f.file_size ?? 0,
-    progress: 100,
-    status: "done",
-  }));
 
 const AnswerSection = (props: AnswerSectionProps) => {
   const [selectedFiles, setSelectedFiles] = useState<UploadFile[]>([]);
@@ -62,21 +50,128 @@ const AnswerSection = (props: AnswerSectionProps) => {
     selId === meId &&
     (showEditor || isWritingAnswer);
 
+  const guardEnabled = showEditor || isWritingAnswer;
+
+  // 파일 시그니처(임시/완료 포함)
+  const fileSig = useMemo(() => buildFileSig(selectedFiles), [selectedFiles]);
+
+  const prevFilesDigestRef = useRef<string>("");
   useEffect(() => {
-    if (!isMyTabAndWriting) return;
+    if (!guardEnabled) return;
+
+    const digest = JSON.stringify({
+      ids: (selectedFileIds ?? []).slice().sort((a, b) => a - b),
+      sig: fileSig,
+    });
+
+    if (prevFilesDigestRef.current === "") {
+      // 최초 진입 시 클린 상태 브로드캐스트(선택 사항)
+      window.dispatchEvent(
+        new CustomEvent("followup:dirty", {
+          detail: { dirty: false, reason: "files-init", key: "answer:files" },
+        })
+      );
+    } else if (digest !== prevFilesDigestRef.current) {
+      // 파일 목록/상태가 달라지면 더티로 브로드캐스트
+      window.dispatchEvent(
+        new CustomEvent("followup:dirty", {
+          detail: { dirty: true, reason: "files-change", key: "answer:files" },
+        })
+      );
+      // 같은 틱 경합 보강
+      queueMicrotask(() =>
+        window.dispatchEvent(
+          new CustomEvent("followup:dirty", {
+            detail: {
+              dirty: true,
+              reason: "files-change",
+              key: "answer:files",
+            },
+          })
+        )
+      );
+    }
+    prevFilesDigestRef.current = digest;
+  }, [guardEnabled, selectedFileIds, fileSig]);
+
+  // Answer 전용 이탈 가드 (로컬 액션만 가드, 라우터 차단 X)
+  const {
+    modalProps: leaveModalForAnswer,
+    setBaseline,
+    setClean,
+    runWithBypass,
+    tryLeave,
+  } = useLeaveGuard(
+    { content: draftContent ?? "", fileIds: selectedFileIds, fileSig },
+    {
+      enabled: guardEnabled,
+      initializeClean: false, // 기준선은 세션 전환시 useEffect에서 설정
+      beforeUnload: true,
+      eventPrefixes: ["answer:"], // editor 변화 + files-change 모두 "answer:"로 브로드캐스트
+      routerBlock: false, // ← 페이지 훅과 충돌 방지
+    }
+  );
+
+  const sessionKey = useMemo(() => {
+    const targetId = selectedComment?.answer_id ?? "none";
+    return `${isMyTabAndWriting ? "on" : "off"}|${isEditMode ? "edit" : "create"}|${targetId}`;
+  }, [isMyTabAndWriting, isEditMode, selectedComment]);
+
+  // 세션키가 바뀌는 순간에만 baseline 및 초기 파일 세팅
+  const lastSessionKeyRef = useRef<string>("");
+  useEffect(() => {
+    if (!isMyTabAndWriting) {
+      lastSessionKeyRef.current = sessionKey;
+      setSelectedFiles([]);
+      setSelectedFileIds([]);
+      // 세션 종료 시 파일 더티도 클린으로 브로드캐스트
+      window.dispatchEvent(
+        new CustomEvent("followup:dirty", {
+          detail: { dirty: false, reason: "files-reset", key: "answer:files" },
+        })
+      );
+      prevFilesDigestRef.current = "";
+      return;
+    }
+
+    if (lastSessionKeyRef.current === sessionKey) return;
+    lastSessionKeyRef.current = sessionKey;
 
     const serverFiles = selectedComment?.files ?? [];
     if (!serverFiles.length) {
       setSelectedFiles([]);
       setSelectedFileIds([]);
+      setBaseline({ content: draftContent ?? "", fileIds: [], fileSig: [] });
+      prevFilesDigestRef.current = JSON.stringify({ ids: [], sig: [] });
       return;
     }
 
     const mapped = mapServerFilesToUploadList(serverFiles);
-
     setSelectedFiles(mapped);
-    setSelectedFileIds(mapped.map(f => f.file_id!).filter(Boolean));
-  }, [isMyTabAndWriting, selectedComment, setSelectedFileIds]);
+    const ids = mapped.map(f => f.file_id!).filter(Boolean);
+    setSelectedFileIds(ids);
+
+    const initialSig = buildFileSig(mapped);
+    setBaseline({
+      content: draftContent ?? "",
+      fileIds: ids,
+      fileSig: initialSig,
+    });
+    prevFilesDigestRef.current = JSON.stringify({
+      ids: ids.slice().sort((a, b) => a - b),
+      sig: initialSig,
+    });
+  }, [sessionKey]);
+
+  const onSelectUserGuarded = (uid: number) => {
+    tryLeave(() => handleSelectTab(uid));
+  };
+
+  const onStartAnswerGuarded = (
+    ...args: Parameters<typeof handleStartAnswer>
+  ) => {
+    tryLeave(() => handleStartAnswer(...args));
+  };
 
   return (
     <div className={answerSectionClasses}>
@@ -98,7 +193,7 @@ const AnswerSection = (props: AnswerSectionProps) => {
           <AnswerList
             answerers={tabsToDisplay}
             selectedUserId={selectedUserId}
-            onSelectUser={handleSelectTab}
+            onSelectUser={onSelectUserGuarded}
           />
         )}
 
@@ -106,10 +201,16 @@ const AnswerSection = (props: AnswerSectionProps) => {
         {isMyTabAndWriting ? (
           // 내 탭이 선택되고 답변 작성 중인 경우 에디터 표시
           <AnswerEditor
+            key={sessionKey} // 세션 전환 시 에디터 강제 재마운트
             mode={isEditMode ? "edit" : "create"}
             initialContent={draftContent}
             onContentChange={setDraftContent}
-            onSubmit={onEditorSubmit}
+            onSubmit={async (content, fileIds) => {
+              await runWithBypass(async () => {
+                await onEditorSubmit(content, fileIds);
+                setClean(); // 제출 성공 시 현재를 기준선으로
+              });
+            }}
             fileIds={selectedFileIds}
             files={selectedFiles}
             setFileIds={setSelectedFileIds}
@@ -121,7 +222,7 @@ const AnswerSection = (props: AnswerSectionProps) => {
             comment={selectedComment}
             isOnlyComment={inquiry.answers.answers.length === 1}
             currentUserId={currentUserId}
-            onStartEdit={handleStartAnswer}
+            onStartEdit={onStartAnswerGuarded}
             onDelete={onDeleteAnswer}
           />
         ) : (
@@ -135,6 +236,9 @@ const AnswerSection = (props: AnswerSectionProps) => {
           </div>
         )}
       </div>
+
+      {/* Answer 전용 이탈 모달 */}
+      <InquiryLeaveModal {...leaveModalForAnswer} />
     </div>
   );
 };

--- a/src/hooks/inquiry/useInquiryApi.ts
+++ b/src/hooks/inquiry/useInquiryApi.ts
@@ -1,7 +1,4 @@
-import { useState } from "react";
-
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { AxiosError } from "axios";
 import { useNavigate } from "react-router-dom";
 
 import { GlobalResponse } from "@/types/common/apiResponse.type";
@@ -18,15 +15,9 @@ import {
   putInquiry,
 } from "@/apis/inquiry/inquiryApi";
 
-const is404 = (e: unknown) => (e as AxiosError)?.response?.status === 404;
-const retryIf404 = (failureCount: number, error: unknown) =>
-  is404(error) && failureCount < 15;
-const retryDelay = (attempt: number) => Math.min(300 * 2 ** attempt, 3000); // 0.3s → 3s
-
 export const useInquiryApi = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [isRedirecting, setIsRedirecting] = useState(false);
 
   const postInquiryMutation = useMutation<
     { result: { inquiry_id: number } },
@@ -34,23 +25,6 @@ export const useInquiryApi = () => {
     { teamId: number; data: PostInquiryRequest }
   >({
     mutationFn: ({ teamId, data }) => postInquiry(teamId, data),
-    onSuccess: async (res, variables) => {
-      const inquiryId = res.result.inquiry_id;
-      const teamId = variables.teamId;
-
-      setIsRedirecting(true);
-      try {
-        await queryClient.prefetchQuery({
-          queryKey: ["teamInquiry", teamId, inquiryId],
-          queryFn: () => getInquiryDetail(teamId, inquiryId),
-          retry: retryIf404,
-          retryDelay,
-        });
-        navigate(`/teams/${teamId}/inquiries/${inquiryId}`);
-      } finally {
-        setIsRedirecting(false);
-      }
-    },
   });
 
   // 문의글 삭제
@@ -90,7 +64,7 @@ export const useInquiryApi = () => {
     },
   });
 
-  const isBlocking = postInquiryMutation.isPending || isRedirecting;
+  const isBlocking = postInquiryMutation.isPending;
   return {
     postInquiryMutation,
     deleteInquiryMutation,

--- a/src/hooks/inquiry/useInquiryApi.ts
+++ b/src/hooks/inquiry/useInquiryApi.ts
@@ -15,7 +15,12 @@ import {
   putInquiry,
 } from "@/apis/inquiry/inquiryApi";
 
-export const useInquiryApi = () => {
+type NavigateWithBypass = (to: string, options?: { replace?: boolean }) => void;
+
+export const useInquiryApi = (opts?: {
+  navigateWithBypass?: NavigateWithBypass;
+  onPutSuccessBeforeNavigate?: () => void;
+}) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
@@ -57,14 +62,21 @@ export const useInquiryApi = () => {
     }) => putInquiry(team_id, inquiry_id, data),
     onSuccess: (_data, vars) => {
       const { team_id, inquiry_id } = vars;
-      // 수정 성공 시, 해당 문의글 상세 정보 새로고침
-      // team_id를 알 수 없으므로, 모든 상세글 쿼리를 무효화
+      // 상세 쿼리 무효화
       queryClient.invalidateQueries({ queryKey: ["teamInquiry"] });
-      navigate(`/teams/${team_id}/inquiries/${inquiry_id}`, { replace: true });
+      opts?.onPutSuccessBeforeNavigate?.();
+      const to = `/teams/${team_id}/inquiries/${inquiry_id}`;
+      // 주입된 내비게이션이 있다면 가드 우회로 실행
+      if (opts?.navigateWithBypass) {
+        opts.navigateWithBypass(to, { replace: true });
+      } else {
+        navigate(to, { replace: true });
+      }
     },
   });
 
-  const isBlocking = postInquiryMutation.isPending;
+  const isBlocking =
+    postInquiryMutation.isPending || putInquiryMutation.isPending;
   return {
     postInquiryMutation,
     deleteInquiryMutation,

--- a/src/hooks/inquiry/useLeaveGuard.ts
+++ b/src/hooks/inquiry/useLeaveGuard.ts
@@ -1,17 +1,58 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+// src/hooks/inquiry/useLeaveGuard.ts
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useBlocker } from "react-router-dom";
 
-/**
- * options:
- *   - enabled: 이탈 감지 활성화 여부 (기본 true)
- *   - initializeClean: 마운트 시점에 현재 snapshot을 baseline으로 잡을지(기본 false)
- *   - beforeUnload: 새로고침/창닫기 차단 활성화(기본 true)
- */
 interface UseLeaveGuardOptions {
   enabled?: boolean;
   initializeClean?: boolean;
   beforeUnload?: boolean;
+  /** followup:dirty 이벤트의 key prefix 목록. 예: ['answer:', 'followup:'] */
+  eventPrefixes?: string[];
+  /** 라우터 네비게이션 차단을 이 훅에서 할지 여부 (페이지 단 하나만 true로!) */
+  routerBlock?: boolean;
+}
+
+type DirtyEventDetail = {
+  dirty: boolean;
+  key?: string;
+  reason?: string;
+};
+
+type SnapshotJson = string;
+
+// react-router의 useBlocker 반환 타입을 그대로 사용
+type BlockerApi = ReturnType<typeof useBlocker>;
+
+/** 안정적인 stringify (키 정렬 + 순환참조 보호) */
+function stableStringify(value: unknown): SnapshotJson {
+  const seen = new WeakSet<object>();
+
+  const isObject = (v: unknown): v is Record<string, unknown> =>
+    typeof v === "object" && v !== null;
+
+  const helper = (v: unknown): unknown => {
+    if (isObject(v)) {
+      if (seen.has(v)) return "[Circular]";
+      seen.add(v);
+
+      if (Array.isArray(v)) {
+        return v.map(helper);
+      }
+
+      const sortedKeys = Object.keys(v).sort();
+      const out: Record<string, unknown> = {};
+      for (const k of sortedKeys) {
+        const val = v[k];
+        if (typeof val === "function" || typeof val === "symbol") continue;
+        out[k] = helper(val);
+      }
+      return out;
+    }
+    return v;
+  };
+
+  return JSON.stringify(helper(value));
 }
 
 export function useLeaveGuard<T extends object>(
@@ -22,100 +63,182 @@ export function useLeaveGuard<T extends object>(
     enabled = true,
     initializeClean = false,
     beforeUnload = true,
+    eventPrefixes,
+    routerBlock = true,
   } = options;
 
-  // baseline(초기 스냅샷)과 현재 snapshot 비교로 dirty 판단
   const [isOpen, setIsOpen] = useState(false);
-  const baselineRef = useRef<string>("");
-  const blockerRef = useRef<ReturnType<typeof useBlocker> | null>(null);
-  const bypassRef = useRef(false); // 특정 시점(제출/의도적 이동)에는 가드 잠시 무시
+  const baselineRef = useRef<SnapshotJson>("");
 
-  // 문자열 스냅샷(안정 비교용)
-  const flat = useMemo(() => JSON.stringify(snapshot), [snapshot]);
+  const blockerRef = useRef<BlockerApi | null>(null);
+  const bypassRef = useRef<boolean>(false);
 
-  // 필요 시(편집 데이터 주입 완료 직후 등) 초기 baseline을 현재로 설정
+  // 최신 enabled를 핸들러에서 읽기 위한 ref
+  const enabledRef = useRef<boolean>(enabled);
+  enabledRef.current = enabled;
+
+  const flat = useMemo<SnapshotJson>(
+    () => stableStringify(snapshot),
+    [snapshot]
+  );
+
+  // --- 스냅샷 기반 더티 ---
   useEffect(() => {
     if (initializeClean && !baselineRef.current) {
       baselineRef.current = flat;
     }
   }, [initializeClean, flat]);
 
-  const isDirty =
+  const snapshotDirty =
     enabled && baselineRef.current !== "" && flat !== baselineRef.current;
 
-  // 내부 라우팅 차단
-  const blocker = useBlocker(enabled && !bypassRef.current && isDirty);
+  // 스냅샷 더티의 "동기 접근"을 위한 ref
+  const snapshotDirtyRef = useRef<boolean>(false);
+  useEffect(() => {
+    snapshotDirtyRef.current = snapshotDirty;
+  }, [snapshotDirty]);
+
+  // --- 이벤트 기반 더티 (followup:dirty) ---
+  const [eventDirty, setEventDirty] = useState<boolean>(false);
+  const eventDirtyRef = useRef<boolean>(false); // 동기 접근용
+  useEffect(() => {
+    if (!eventPrefixes || eventPrefixes.length === 0) return;
+
+    const onDirty = (e: Event) => {
+      const ce = e as CustomEvent<DirtyEventDetail>;
+      const key = ce.detail?.key ?? "";
+      const match = eventPrefixes.some(p => key.startsWith(p));
+      if (!match) return;
+
+      const next = Boolean(ce.detail?.dirty);
+      eventDirtyRef.current = next; // 즉시 반영
+      setEventDirty(next); // 렌더 반영
+    };
+
+    window.addEventListener("followup:dirty", onDirty);
+    return () => window.removeEventListener("followup:dirty", onDirty);
+  }, [eventPrefixes]);
+
+  // 렌더에서 쓰는 유효 더티 (라우팅 차단용)
+  const effectiveDirty = snapshotDirty || eventDirty;
+
+  // beforeunload / tryLeave에서 즉시 쓰는 유효 더티 (ref)
+  const getEffectiveDirtyNow = () =>
+    snapshotDirtyRef.current || eventDirtyRef.current;
+
+  // 라우팅 차단 (페이지 단 하나의 훅만 routerBlock=true 여야 함)
+  const blocker = useBlocker(
+    routerBlock && enabled && !bypassRef.current && effectiveDirty
+  );
 
   useEffect(() => {
+    if (!routerBlock) return;
     blockerRef.current = blocker;
-    if (blocker.state === "blocked") {
-      setIsOpen(true);
+    if (blocker.state === "blocked") setIsOpen(true);
+  }, [blocker, routerBlock]);
+
+  // 로컬 액션 지연 실행 저장소
+  const deferredRef = useRef<null | (() => void)>(null);
+
+  // 확인: 라우팅이면 proceed, 로컬이면 지연된 액션을 우회 실행
+  const confirmLeave = useCallback(() => {
+    const blocked =
+      routerBlock &&
+      blockerRef.current !== null &&
+      blockerRef.current.state === "blocked";
+
+    setIsOpen(false);
+
+    if (blocked) {
+      blockerRef.current?.proceed?.();
+      return;
     }
-  }, [blocker]);
 
-  const confirmLeave = () => {
-    blockerRef.current?.proceed?.();
+    const run = deferredRef.current;
+    deferredRef.current = null;
+
+    if (run) {
+      bypassRef.current = true;
+      try {
+        run();
+      } finally {
+        bypassRef.current = false;
+      }
+    }
+  }, [routerBlock]);
+
+  const cancelLeave = useCallback(() => {
+    const blocked =
+      routerBlock &&
+      blockerRef.current !== null &&
+      blockerRef.current.state === "blocked";
+
     setIsOpen(false);
-  };
+    if (blocked) blockerRef.current?.reset?.();
+    deferredRef.current = null;
+  }, [routerBlock]);
 
-  const cancelLeave = () => {
-    blockerRef.current?.reset?.();
-    setIsOpen(false);
-  };
-
-  // 새로고침/탭닫기 차단
+  // beforeunload: 항상 1회 등록, 동작 여부는 ref로 판단
   useEffect(() => {
     if (!beforeUnload) return;
     const onBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (!isDirty) return;
-      e.preventDefault();
-      e.returnValue = "";
+      if (enabledRef.current && !bypassRef.current && getEffectiveDirtyNow()) {
+        e.preventDefault();
+        e.returnValue = "";
+      }
     };
     window.addEventListener("beforeunload", onBeforeUnload);
     return () => window.removeEventListener("beforeunload", onBeforeUnload);
-  }, [isDirty, beforeUnload]);
+  }, [beforeUnload]);
 
-  // 제출 성공 등, 현재 상태를 "깨끗한 상태"로 간주하고 싶을 때 호출
-  const setClean = () => {
+  const setClean = useCallback(() => {
     baselineRef.current = flat;
-  };
+    eventDirtyRef.current = false;
+    setEventDirty(false);
+  }, [flat]);
 
-  // 외부에서 임의로 baseline을 특정 상태로 맞추고 싶을 때
-  const setBaseline = (nextSnapshot: T) => {
-    baselineRef.current = JSON.stringify(nextSnapshot);
-  };
+  const setBaseline = useCallback((nextSnapshot: T) => {
+    baselineRef.current = stableStringify(nextSnapshot);
+    eventDirtyRef.current = false;
+    setEventDirty(false);
+  }, []);
 
-  // 어떤 동작을 수행하는 동안에는 가드를 잠시 비활성화
-  // 예: 의도적 라우팅, 제출 직후 이동 등
-  async function runWithBypass<TOut>(fn: () => Promise<TOut> | TOut) {
-    bypassRef.current = true;
-    try {
-      const r = await fn();
-      return r;
-    } finally {
-      bypassRef.current = false;
+  const runWithBypass = useCallback(
+    async <TOut>(fn: () => Promise<TOut> | TOut) => {
+      bypassRef.current = true;
+      try {
+        return await fn();
+      } finally {
+        bypassRef.current = false;
+      }
+    },
+    []
+  );
+
+  // 로컬 액션 가드: 더티면 모달을 띄우고, 아니면 즉시 실행
+  const tryLeave = useCallback((action: () => void) => {
+    if (!enabledRef.current) {
+      action();
+      return;
     }
-  }
+    if (getEffectiveDirtyNow()) {
+      deferredRef.current = action;
+      setIsOpen(true);
+    } else {
+      action();
+    }
+  }, []);
 
   return {
-    // 상태
     isOpen,
-    isDirty,
-
-    // 모달 핸들러
+    isDirty: effectiveDirty,
     confirmLeave,
     cancelLeave,
-
-    // 모달에 바로 바인딩할 props
-    modalProps: {
-      isOpen,
-      onConfirm: confirmLeave,
-      onCancel: cancelLeave,
-    },
-
-    // 베이스라인/우회 도구
+    modalProps: { isOpen, onConfirm: confirmLeave, onCancel: cancelLeave },
     setClean,
     setBaseline,
     runWithBypass,
+    tryLeave,
+    bypassRef,
   };
 }

--- a/src/hooks/inquiry/useLeaveGuard.ts
+++ b/src/hooks/inquiry/useLeaveGuard.ts
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { useBlocker } from "react-router-dom";
+
+/**
+ * options:
+ *   - enabled: 이탈 감지 활성화 여부 (기본 true)
+ *   - initializeClean: 마운트 시점에 현재 snapshot을 baseline으로 잡을지(기본 false)
+ *   - beforeUnload: 새로고침/창닫기 차단 활성화(기본 true)
+ */
+interface UseLeaveGuardOptions {
+  enabled?: boolean;
+  initializeClean?: boolean;
+  beforeUnload?: boolean;
+}
+
+export function useLeaveGuard<T extends object>(
+  snapshot: T,
+  options: UseLeaveGuardOptions = {}
+) {
+  const {
+    enabled = true,
+    initializeClean = false,
+    beforeUnload = true,
+  } = options;
+
+  // baseline(초기 스냅샷)과 현재 snapshot 비교로 dirty 판단
+  const [isOpen, setIsOpen] = useState(false);
+  const baselineRef = useRef<string>("");
+  const blockerRef = useRef<ReturnType<typeof useBlocker> | null>(null);
+  const bypassRef = useRef(false); // 특정 시점(제출/의도적 이동)에는 가드 잠시 무시
+
+  // 문자열 스냅샷(안정 비교용)
+  const flat = useMemo(() => JSON.stringify(snapshot), [snapshot]);
+
+  // 필요 시(편집 데이터 주입 완료 직후 등) 초기 baseline을 현재로 설정
+  useEffect(() => {
+    if (initializeClean && !baselineRef.current) {
+      baselineRef.current = flat;
+    }
+  }, [initializeClean, flat]);
+
+  const isDirty =
+    enabled && baselineRef.current !== "" && flat !== baselineRef.current;
+
+  // 내부 라우팅 차단
+  const blocker = useBlocker(enabled && !bypassRef.current && isDirty);
+
+  useEffect(() => {
+    blockerRef.current = blocker;
+    if (blocker.state === "blocked") {
+      setIsOpen(true);
+    }
+  }, [blocker]);
+
+  const confirmLeave = () => {
+    blockerRef.current?.proceed?.();
+    setIsOpen(false);
+  };
+
+  const cancelLeave = () => {
+    blockerRef.current?.reset?.();
+    setIsOpen(false);
+  };
+
+  // 새로고침/탭닫기 차단
+  useEffect(() => {
+    if (!beforeUnload) return;
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!isDirty) return;
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [isDirty, beforeUnload]);
+
+  // 제출 성공 등, 현재 상태를 "깨끗한 상태"로 간주하고 싶을 때 호출
+  const setClean = () => {
+    baselineRef.current = flat;
+  };
+
+  // 외부에서 임의로 baseline을 특정 상태로 맞추고 싶을 때
+  const setBaseline = (nextSnapshot: T) => {
+    baselineRef.current = JSON.stringify(nextSnapshot);
+  };
+
+  // 어떤 동작을 수행하는 동안에는 가드를 잠시 비활성화
+  // 예: 의도적 라우팅, 제출 직후 이동 등
+  async function runWithBypass<TOut>(fn: () => Promise<TOut> | TOut) {
+    bypassRef.current = true;
+    try {
+      const r = await fn();
+      return r;
+    } finally {
+      bypassRef.current = false;
+    }
+  }
+
+  return {
+    // 상태
+    isOpen,
+    isDirty,
+
+    // 모달 핸들러
+    confirmLeave,
+    cancelLeave,
+
+    // 모달에 바로 바인딩할 props
+    modalProps: {
+      isOpen,
+      onConfirm: confirmLeave,
+      onCancel: cancelLeave,
+    },
+
+    // 베이스라인/우회 도구
+    setClean,
+    setBaseline,
+    runWithBypass,
+  };
+}

--- a/src/hooks/useInquiryDetail.ts
+++ b/src/hooks/useInquiryDetail.ts
@@ -12,6 +12,7 @@ import {
   useGetLastSentMailTime,
   useInquiryManagementApi,
 } from "@/hooks/inquiry/useInquiryManagementApi";
+import { useLeaveGuard } from "@/hooks/inquiry/useLeaveGuard";
 import { useMyProfile } from "@/hooks/profile/useProfileApi";
 import { formatRemain, parseUtc } from "@/utils/dateUtils";
 import type { Comment, User } from "@/types/inquiryTypes";
@@ -31,7 +32,6 @@ const dedupValidIds = (ids: Array<number | null | undefined>) =>
   );
 
 export const useInquiryDetail = () => {
-  // 훅 호출
   const navigate = useNavigate();
   const { team_id, inquiry_id } = useParams<{
     team_id: string;
@@ -44,6 +44,7 @@ export const useInquiryDetail = () => {
     isError,
     error,
   } = useGetTeamInquiryDetail(Number(team_id), Number(inquiry_id));
+
   const { data: myProfileResponse } = useMyProfile();
   const {
     postAnswerMutation,
@@ -115,9 +116,7 @@ export const useInquiryDetail = () => {
 
       // 중복 제거를 위해 기존 답변자 중에 내가 없을 때만 추가
       const hasMyTab = uniqueAnswerers.some(a => a.user_id === currentUserId);
-      if (!hasMyTab) {
-        uniqueAnswerers.push(myInfo);
-      }
+      if (!hasMyTab) uniqueAnswerers.push(myInfo);
     }
 
     return uniqueAnswerers.map(a => ({
@@ -146,12 +145,11 @@ export const useInquiryDetail = () => {
   useEffect(() => {
     if (inquiryData && !selectedUserId) {
       const firstAnswerer = inquiryData.answers.answers.find(c => c.user);
-      if (firstAnswerer) {
-        setSelectedUserId(firstAnswerer.user.user_id);
-      }
+      if (firstAnswerer) setSelectedUserId(firstAnswerer.user.user_id);
     }
   }, [inquiryData, selectedUserId]);
 
+  // 메일 쿨다운 타이머
   useEffect(() => {
     // 404면 쿨다운 없음
     if (
@@ -185,7 +183,6 @@ export const useInquiryDetail = () => {
     };
 
     tick();
-
     const id = window.setInterval(tick, 1000);
 
     // 탭 복귀 시 보정
@@ -200,7 +197,28 @@ export const useInquiryDetail = () => {
     };
   }, [lastSentTimeResponse, isMailTimeError, mailTimeError]);
 
-  // 실제 API를 호출하는 콜백 함수들
+  // 이탈 가드
+  const leaveSnapshot = useMemo(
+    () => ({
+      editing: Boolean(editingComment || isWritingAnswer || showEditor),
+      content: draftContent.trim(),
+      fileIds: dedupValidIds(selectedFileIds).sort((a, b) => a - b),
+    }),
+    [editingComment, isWritingAnswer, showEditor, draftContent, selectedFileIds]
+  );
+
+  const {
+    modalProps: leaveModal,
+    setBaseline,
+    setClean,
+    runWithBypass,
+  } = useLeaveGuard(leaveSnapshot, {
+    enabled: Boolean(editingComment || isWritingAnswer || showEditor),
+    initializeClean: true,
+    beforeUnload: true,
+  });
+
+  // 실제 API 콜백들
   const onConfirmInquiry = async () => {
     try {
       await postInquiryConfirmMutation.mutateAsync({
@@ -214,35 +232,28 @@ export const useInquiryDetail = () => {
   const onSubmitAnswer = async () => {
     if (draftContent.trim().length === 0) return;
 
-    // dedup + 정렬(서버에서 순서 민감하지 않더라도 안정성↑)
     const safeIds = dedupValidIds(selectedFileIds).sort((a, b) => a - b);
 
     try {
       if (editingComment) {
         await putAnswerMutation.mutateAsync({
           answer_id: editingComment.answer_id,
-          data: {
-            content: draftContent,
-            file_ids: safeIds, // ✅ 항상 전체 목록 전달
-          },
+          data: { content: draftContent, file_ids: safeIds },
         });
-
         setSelectedUserId(editingComment.user.user_id);
       } else {
         await postAnswerMutation.mutateAsync({
           inquiry_id: Number(inquiry_id),
-          data: {
-            content: draftContent,
-            file_ids: safeIds, // ✅ 새 등록도 현재 선택 전체
-          },
+          data: { content: draftContent, file_ids: safeIds },
         });
-
         if (currentUserId) {
           setTimeout(() => setSelectedUserId(currentUserId), 200);
         }
       }
 
-      // 완료 후 초기화
+      setClean();
+
+      // 폼 초기화
       setEditingComment(null);
       setDraftContent("");
       setShowEditor(false);
@@ -254,10 +265,8 @@ export const useInquiryDetail = () => {
   };
 
   const onSendNotification = async () => {
-    // UX 즉시 반응: 4시간 쿨다운 시작
     setNotificationSent(true);
     setRemainingTime(formatRemain(NOTIFICATION_COOLDOWN));
-
     try {
       await postInquiryNotifyMutation.mutateAsync({
         inquiry_id: Number(inquiry_id),
@@ -278,7 +287,6 @@ export const useInquiryDetail = () => {
           const remainingAnswers = inquiryData?.answers.answers.filter(
             answer => answer.answer_id !== answerId
           );
-
           if (remainingAnswers && remainingAnswers.length > 0) {
             setSelectedUserId(remainingAnswers[0].user.user_id);
           } else {
@@ -293,7 +301,7 @@ export const useInquiryDetail = () => {
         setIsWritingAnswer(false);
         setEditingComment(null);
         setDraftContent("");
-        setSelectedFileIds([]); // ✅ 초기화
+        setSelectedFileIds([]);
       }
     } catch (error) {
       console.error("답변 삭제 실패:", error);
@@ -307,7 +315,7 @@ export const useInquiryDetail = () => {
         team_id: Number(team_id),
         inquiry_id: Number(inquiry_id),
       });
-      navigate(-1);
+      runWithBypass(() => navigate(-1));
     } catch (error) {
       console.error("문의글 삭제 실패:", error);
     }
@@ -359,30 +367,36 @@ export const useInquiryDetail = () => {
       setEditingComment(commentToEdit);
       setDraftContent(commentToEdit.content ?? "");
       const fileIds = (commentToEdit.files ?? []).map(f => f.file_id);
-      setSelectedFileIds(dedupValidIds(fileIds)); // ✅ 기존 파일 로드
+      const safe = dedupValidIds(fileIds).sort((a, b) => a - b);
+      setSelectedFileIds(safe);
+
+      setBaseline({
+        editing: true,
+        content: (commentToEdit.content ?? "").trim(),
+        fileIds: safe,
+      });
     } else {
       setEditingComment(null);
       setDraftContent(myComment?.content || "");
-      setSelectedFileIds([]); // ✅ 새 답변 시작 시 초기화
+      setSelectedFileIds([]);
+
+      setBaseline({
+        editing: true,
+        content: "",
+        fileIds: [],
+      });
     }
+
     setShowEditor(true);
     setIsWritingAnswer(true);
-    if (currentUserId) {
-      setSelectedUserId(currentUserId);
-    }
+    if (currentUserId) setSelectedUserId(currentUserId);
   };
 
   const handleSelectTab = (userId: number) => {
     setSelectedUserId(userId);
-
     if (userId === currentUserId) {
-      if (isWritingAnswer || editingComment) {
-        setShowEditor(true);
-      } else if (myComment) {
-        setShowEditor(false);
-      } else {
-        setShowEditor(false);
-      }
+      if (isWritingAnswer || editingComment) setShowEditor(true);
+      else setShowEditor(false);
     } else {
       setShowEditor(false);
     }
@@ -404,14 +418,12 @@ export const useInquiryDetail = () => {
   // 개인 알림 설정 토글 함수
   const onToggleNotification = async () => {
     if (!inquiryData) return;
-
     try {
-      const newNotificationState = !inquiryData.is_notification_enabled;
-
+      const newFlag = !inquiryData.is_notification_enabled;
       await putInquiryNotificationMutation.mutateAsync({
         team_id: Number(team_id),
         inquiry_id: Number(inquiry_id),
-        is_notification_enabled: newNotificationState,
+        is_notification_enabled: newFlag,
       });
     } catch (error) {
       console.error("알림 설정 변경 실패:", error);
@@ -436,6 +448,7 @@ export const useInquiryDetail = () => {
     isWritingAnswer,
     notificationSent,
     remainingTime,
+
     isAssigneeModalOpen,
     selectedAssignees,
     setSelectedAssignees,
@@ -443,8 +456,10 @@ export const useInquiryDetail = () => {
     handleCloseAssigneeModal,
     handleUpdateAssignees,
     putInquiryAssigneeMutation,
+
     modalProps,
     closeModal: () => setModalProps(null),
+
     handleStartAnswer,
     handleSelectTab,
     onEditorSubmit,
@@ -452,9 +467,12 @@ export const useInquiryDetail = () => {
     handleDeleteInquiry,
     handleNotify,
     onDeleteAnswer,
+
     selectedFileIds,
     setSelectedFileIds,
     isEditMode: !!editingComment,
     onToggleNotification,
+
+    leaveModal,
   };
 };

--- a/src/hooks/useInquiryDetail.ts
+++ b/src/hooks/useInquiryDetail.ts
@@ -1,3 +1,4 @@
+// src/hooks/useInquiryDetail.ts
 import { useEffect, useMemo, useState } from "react";
 
 import { AxiosError } from "axios";
@@ -93,7 +94,6 @@ export const useInquiryDetail = () => {
   // 탭 목록에 현재 사용자 포함 (답변 작성 중일 때)
   const tabsToDisplay = useMemo(() => {
     if (!inquiryData || !currentUserId) return [];
-
     const answerers = inquiryData.answers.answers
       .map(c => c.user)
       .filter((user): user is NonNullable<typeof user> => !!user);
@@ -171,7 +171,7 @@ export const useInquiryDetail = () => {
         setRemainingTime("");
         return;
       }
-      const diff = Date.now() - +base; // 경과
+      const diff = Date.now() - +base;
       const remain = NOTIFICATION_COOLDOWN - diff;
       if (remain <= 0) {
         setNotificationSent(false);
@@ -214,8 +214,10 @@ export const useInquiryDetail = () => {
     runWithBypass,
   } = useLeaveGuard(leaveSnapshot, {
     enabled: Boolean(editingComment || isWritingAnswer || showEditor),
-    initializeClean: true,
+    initializeClean: false, // 자동 기준선 금지
     beforeUnload: true,
+    eventPrefixes: ["answer:", "followup:"],
+    routerBlock: true, // 페이지 레벨에서만 true
   });
 
   // 실제 API 콜백들
@@ -276,12 +278,11 @@ export const useInquiryDetail = () => {
     }
   };
 
-  // 답변 삭제 함수
+  // 답변 삭제
   const onDeleteAnswer = async (answerId: number) => {
     try {
       await deleteAnswerMutation.mutateAsync({ answer_id: answerId });
 
-      // 답변 삭제 성공 후 처리
       if (selectedComment?.answer_id === answerId) {
         setTimeout(() => {
           const remainingAnswers = inquiryData?.answers.answers.filter(
@@ -308,7 +309,7 @@ export const useInquiryDetail = () => {
     }
   };
 
-  // 문의글 삭제 함수
+  // 문의글 삭제
   const onDeletePost = async () => {
     try {
       await deleteInquiryMutation.mutateAsync({
@@ -321,7 +322,7 @@ export const useInquiryDetail = () => {
     }
   };
 
-  // 모달을 여는 함수들을 생성
+  // 모달 구성
   const modals = useInquiryModals({
     setModalProps,
     callbacks: {
@@ -332,7 +333,7 @@ export const useInquiryDetail = () => {
     },
   });
 
-  // 핸들러 함수
+  // 담당자 모달
   const handleOpenAssigneeModal = () => {
     const initialAssignees =
       inquiryData?.assignees.map(a => ({
@@ -343,11 +344,7 @@ export const useInquiryDetail = () => {
     setSelectedAssignees(initialAssignees);
     setIsAssigneeModalOpen(true);
   };
-
-  const handleCloseAssigneeModal = () => {
-    setIsAssigneeModalOpen(false);
-  };
-
+  const handleCloseAssigneeModal = () => setIsAssigneeModalOpen(false);
   const handleUpdateAssignees = async () => {
     const assigneeIds = selectedAssignees.map(a => a.id);
     try {
@@ -362,29 +359,32 @@ export const useInquiryDetail = () => {
     }
   };
 
+  // **핵심**: 편집 시작 시 baseline을 "가장 먼저" 고정하고, 그 다음 상태 세팅
   const handleStartAnswer = (commentToEdit?: Comment) => {
     if (commentToEdit) {
-      setEditingComment(commentToEdit);
-      setDraftContent(commentToEdit.content ?? "");
       const fileIds = (commentToEdit.files ?? []).map(f => f.file_id);
       const safe = dedupValidIds(fileIds).sort((a, b) => a - b);
-      setSelectedFileIds(safe);
 
       setBaseline({
         editing: true,
         content: (commentToEdit.content ?? "").trim(),
         fileIds: safe,
       });
-    } else {
-      setEditingComment(null);
-      setDraftContent(myComment?.content || "");
-      setSelectedFileIds([]);
 
+      setEditingComment(commentToEdit);
+      setDraftContent(commentToEdit.content ?? "");
+      setSelectedFileIds(safe);
+    } else {
       setBaseline({
         editing: true,
         content: "",
         fileIds: [],
       });
+
+      // 2) 이후에 상태 변경
+      setEditingComment(null);
+      setDraftContent(myComment?.content || "");
+      setSelectedFileIds([]);
     }
 
     setShowEditor(true);
@@ -415,7 +415,6 @@ export const useInquiryDetail = () => {
   const handleDeleteInquiry = () => modals.openDeletePostModal();
   const handleNotify = () => modals.openSendNotificationModal();
 
-  // 개인 알림 설정 토글 함수
   const onToggleNotification = async () => {
     if (!inquiryData) return;
     try {

--- a/src/pages/inquiry/InquiryFormPage.tsx
+++ b/src/pages/inquiry/InquiryFormPage.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
 import clsx from "clsx";
-import { useLocation, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 import PencilIcon from "@/assets/svgs/inquiry/pencil.svg";
 import Button from "@/components/common/Button";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
+import InquiryLeaveModal from "@/components/inquiry/common/InquiryLeaveModal";
 import InquiryForm from "@/components/inquiry/form/InquiryForm";
 import InquiryFormModal from "@/components/inquiry/form/InquiryFormModal";
 import SelectDropdown from "@/components/inquiry/form/SelectDropdown";
@@ -15,10 +17,14 @@ import {
   useGetTeamInquiryDetail,
   useInquiryApi,
 } from "@/hooks/inquiry/useInquiryApi";
+import { useLeaveGuard } from "@/hooks/inquiry/useLeaveGuard";
 import { useInitialOrgSelection } from "@/hooks/team/useInitialOrgSelection";
 import { useOrganizationSelector } from "@/hooks/team/useOrganizationSelector";
+import { retryDelay, retryIf404 } from "@/utils/queryRetryUtils";
 import { InquiryFile } from "@/types/file/file.type";
 import { PostInquiryRequest } from "@/types/inquiry/inquiryApi.type";
+
+import { getInquiryDetail } from "@/apis/inquiry/detail/inquiryDetailApi";
 
 type FormLocationState = {
   teamId?: number;
@@ -44,6 +50,9 @@ const InquiryFormPage = () => {
 
   const [searchParams] = useSearchParams();
   const location = useLocation() as { state?: FormLocationState };
+
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const mode = searchParams.get("mode");
   const isEdit = mode === "edit";
@@ -217,6 +226,39 @@ const InquiryFormPage = () => {
     [files]
   );
 
+  const leaveSnapshot = useMemo(
+    () => ({
+      teamId,
+      title: title?.trim() ?? "",
+      content: content?.trim() ?? "",
+      assigneeIds: [...assigneeIds].sort(),
+      referenceIds: [...referenceIds].sort(),
+      fileIds: fileIdsForSubmit, // 업로드 완료 파일만
+    }),
+    [teamId, title, content, assigneeIds, referenceIds, fileIdsForSubmit]
+  );
+
+  // prefetch/navigate 동안에도 로딩/가드 OFF를 유지하기 위한 로컬 상태
+  const [isRedirecting, setIsRedirecting] = useState(false);
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
+
+  const {
+    modalProps: leaveModal, // { isOpen, onConfirm, onCancel }
+    setClean,
+    setBaseline,
+    runWithBypass,
+  } = useLeaveGuard(leaveSnapshot, {
+    enabled: !isBlocking && !isConfirmModalOpen && !isRedirecting, // ⬅️ 보강
+    initializeClean: !isEdit,
+    beforeUnload: !isBlocking && !isRedirecting,
+  });
+
   // 편집 모드 데이터 주입
   useEffect(() => {
     if (!isEdit || !editDetail) return;
@@ -264,6 +306,7 @@ const InquiryFormPage = () => {
 
     clearDraftState();
     appliedEditRef.current = true;
+    setClean();
   }, [
     isEdit,
     editDetail,
@@ -306,12 +349,22 @@ const InquiryFormPage = () => {
       file_ids: fileIdsForSubmit,
     };
 
+    const cleanSnapshot = {
+      teamId,
+      title: "",
+      content: "",
+      assigneeIds: [] as number[],
+      referenceIds: [] as number[],
+      fileIds: [] as number[],
+    };
+
     if (isEdit && editTeamId && editInquiryId) {
       putInquiryMutation.mutate(
         { team_id: editTeamId, inquiry_id: editInquiryId, data: payload },
         {
           onSuccess: () => {
             setIsConfirmModalOpen(false);
+            setBaseline(cleanSnapshot);
             clearDraftState();
           },
         }
@@ -325,9 +378,29 @@ const InquiryFormPage = () => {
       postInquiryMutation.mutate(
         { teamId, data: payload },
         {
-          onSuccess: () => {
-            setIsConfirmModalOpen(false);
+          onSuccess: async res => {
+            const inquiryId = res.result.inquiry_id;
+
+            // 등록 직후: 폼 초기 상태를 baseline으로 고정
+            setBaseline(cleanSnapshot);
+            // 외부/드래프트 상태 초기화 (모달은 닫지 않음)
             clearDraftState();
+            // 상세 prefetch & 이동 동안에도 "등록중..." 유지
+            setIsRedirecting(true);
+            try {
+              await runWithBypass(async () => {
+                await queryClient.prefetchQuery({
+                  queryKey: ["teamInquiry", teamId, inquiryId],
+                  queryFn: () => getInquiryDetail(teamId, inquiryId),
+                  retry: retryIf404,
+                  retryDelay,
+                });
+
+                navigate(`/teams/${teamId}/inquiries/${inquiryId}`);
+              });
+            } finally {
+              if (mountedRef.current) setIsRedirecting(false);
+            }
           },
         }
       );
@@ -342,14 +415,18 @@ const InquiryFormPage = () => {
     assigneeIds,
     referenceIds,
     fileIdsForSubmit,
-    fileIds,
     putInquiryMutation,
     postInquiryMutation,
     deleteDraftBeforeSubmit,
     clearDraftState,
+    setBaseline,
+    navigate,
+    queryClient,
+    runWithBypass,
   ]);
 
   const pageLoading = isLoadingEdit;
+  const isBusy = pageLoading || isBlocking || isRedirecting;
 
   if (pageLoading) {
     return <LoadingSpinner fullscreen={true} />;
@@ -370,21 +447,21 @@ const InquiryFormPage = () => {
             value={groupId ?? 0}
             onChange={handleGroupChange}
             placeholder="그룹 선택"
-            disabled={isEdit || pageLoading}
+            disabled={isEdit || isBusy}
           />
           <SelectDropdown
             options={divisionOptions}
             value={divisionId ?? 0}
             onChange={handleDivisionChange}
             placeholder="본부 선택"
-            disabled={isEdit || !groupId || pageLoading}
+            disabled={isEdit || !groupId || isBusy}
           />
           <SelectDropdown
             options={teamOptions}
             value={teamId ?? 0}
             onChange={handleTeamChange}
             placeholder="팀 선택"
-            disabled={isEdit || !divisionId || pageLoading}
+            disabled={isEdit || !divisionId || isBusy}
           />
         </div>
 
@@ -411,12 +488,12 @@ const InquiryFormPage = () => {
           <Button
             buttonType={isDraftSaved ? "done" : "white"}
             onClick={handleClickTempSave}
-            disabled={isDraftSaved}
+            disabled={isDraftSaved || isBusy}
           >
             {isDraftSaved ? "임시저장완료" : "임시저장"}
           </Button>
         )}
-        <Button buttonType="blue" onClick={handleSubmit} disabled={pageLoading}>
+        <Button buttonType="blue" onClick={handleSubmit} disabled={isBusy}>
           <PencilIcon />
           <span className="text-heading3 text-white">
             {isEdit ? "문의 수정하기" : "문의 등록하기"}
@@ -434,10 +511,12 @@ const InquiryFormPage = () => {
         isConfirmOpen={isConfirmModalOpen}
         onCloseConfirm={() => setIsConfirmModalOpen(false)}
         onConfirmSubmit={confirmSubmit}
-        isSubmitting={isBlocking}
+        isSubmitting={isBlocking || isRedirecting}
         draftModalMode={draftModalMode}
         onOverwriteDraft={saveCurrentAsDraftReplacingExisting}
       />
+
+      <InquiryLeaveModal {...leaveModal} />
     </section>
   );
 };

--- a/src/pages/inquiry/InquiryFormPage.tsx
+++ b/src/pages/inquiry/InquiryFormPage.tsx
@@ -197,8 +197,13 @@ const InquiryFormPage = () => {
     setMissingField,
   });
 
-  const { postInquiryMutation, putInquiryMutation, isBlocking } =
-    useInquiryApi();
+  const { postInquiryMutation, putInquiryMutation, isBlocking } = useInquiryApi(
+    {
+      navigateWithBypass: (to, options) =>
+        runWithBypass(() => navigate(to, options)),
+      onPutSuccessBeforeNavigate: () => setClean(),
+    }
+  );
 
   const hasEditIds =
     isEdit && editTeamId !== undefined && editInquiryId !== undefined;
@@ -364,7 +369,6 @@ const InquiryFormPage = () => {
         {
           onSuccess: () => {
             setIsConfirmModalOpen(false);
-            setBaseline(cleanSnapshot);
             clearDraftState();
           },
         }
@@ -381,11 +385,8 @@ const InquiryFormPage = () => {
           onSuccess: async res => {
             const inquiryId = res.result.inquiry_id;
 
-            // 등록 직후: 폼 초기 상태를 baseline으로 고정
             setBaseline(cleanSnapshot);
-            // 외부/드래프트 상태 초기화 (모달은 닫지 않음)
             clearDraftState();
-            // 상세 prefetch & 이동 동안에도 "등록중..." 유지
             setIsRedirecting(true);
             try {
               await runWithBypass(async () => {

--- a/src/pages/inquiry/InquiryFormPage.tsx
+++ b/src/pages/inquiry/InquiryFormPage.tsx
@@ -41,6 +41,9 @@ type FormLocationState = {
 const firstDefined = <T,>(...vals: Array<T | undefined>) =>
   vals.find(v => v !== undefined);
 
+// 정렬 유틸
+const sortNums = (xs: number[] = []) => [...xs].sort((a, b) => a - b);
+
 const InquiryFormPage = () => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
@@ -231,27 +234,34 @@ const InquiryFormPage = () => {
     [files]
   );
 
+  const sortedFileIdsForSubmit = useMemo(
+    () => sortNums(fileIdsForSubmit),
+    [fileIdsForSubmit]
+  );
+
   const leaveSnapshot = useMemo(
     () => ({
       teamId,
-      title: title?.trim() ?? "",
-      content: content?.trim() ?? "",
-      assigneeIds: [...assigneeIds].sort(),
-      referenceIds: [...referenceIds].sort(),
-      fileIds: fileIdsForSubmit, // 업로드 완료 파일만
+      title: (title ?? "").trim(),
+      content: (content ?? "").trim(),
+      assigneeIds: sortNums(assigneeIds),
+      referenceIds: sortNums(referenceIds),
+      fileIds: sortedFileIdsForSubmit, // 업로드 완료 파일만
     }),
-    [teamId, title, content, assigneeIds, referenceIds, fileIdsForSubmit]
+    [teamId, title, content, assigneeIds, referenceIds, sortedFileIdsForSubmit]
   );
 
   // prefetch/navigate 동안에도 로딩/가드 OFF를 유지하기 위한 로컬 상태
   const [isRedirecting, setIsRedirecting] = useState(false);
   const mountedRef = useRef(true);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    return () => {
       mountedRef.current = false;
-    },
-    []
-  );
+    };
+  }, []);
+
+  // 편집 하이드레이션 완료되기 전에는 가드 비활성
+  const [hydrationDone, setHydrationDone] = useState(!isEdit);
 
   const {
     modalProps: leaveModal, // { isOpen, onConfirm, onCancel }
@@ -259,9 +269,10 @@ const InquiryFormPage = () => {
     setBaseline,
     runWithBypass,
   } = useLeaveGuard(leaveSnapshot, {
-    enabled: !isBlocking && !isConfirmModalOpen && !isRedirecting, // ⬅️ 보강
+    enabled:
+      hydrationDone && !isBlocking && !isConfirmModalOpen && !isRedirecting,
     initializeClean: !isEdit,
-    beforeUnload: !isBlocking && !isRedirecting,
+    beforeUnload: hydrationDone && !isBlocking && !isRedirecting,
   });
 
   // 편집 모드 데이터 주입
@@ -295,6 +306,7 @@ const InquiryFormPage = () => {
         status: "done" as const,
       }))
     );
+
     if (
       editDetail.group?.group_id &&
       editDetail.division?.division_id &&
@@ -311,11 +323,39 @@ const InquiryFormPage = () => {
 
     clearDraftState();
     appliedEditRef.current = true;
-    setClean();
+
+    // editDetail 기반 정렬된 baseline으로 고정
+    const baselineFromEdit = {
+      teamId: editDetail.team?.team_id ?? editTeamId ?? teamId ?? 0,
+      title: (editDetail.title ?? "").trim(),
+      content: (editDetail.content ?? "").trim(),
+      assigneeIds: sortNums(
+        (editDetail.assignees ?? [])
+          .map(u => u.user_id)
+          .filter((id): id is number => Number.isFinite(id) && id > 0)
+      ),
+      referenceIds: sortNums(
+        (editDetail.observers ?? [])
+          .map(u => u.userId)
+          .filter((id): id is number => Number.isFinite(id) && id > 0)
+      ),
+      fileIds: sortNums(
+        ((editDetail.files ?? []) as InquiryFile[]).map(f => f.file_id)
+      ),
+    };
+
+    const schedule = (fn: () => void) =>
+      queueMicrotask ? queueMicrotask(fn) : setTimeout(fn, 0);
+
+    schedule(() => {
+      setBaseline(baselineFromEdit);
+      setHydrationDone(true);
+    });
   }, [
     isEdit,
     editDetail,
     editTeamId,
+    teamId,
     setTitle,
     setContent,
     setAssigneeIds,
@@ -325,6 +365,7 @@ const InquiryFormPage = () => {
     setFromIds,
     handleTeamChange,
     clearDraftState,
+    setBaseline,
   ]);
 
   const handleSubmit = useCallback(() => {
@@ -351,7 +392,7 @@ const InquiryFormPage = () => {
       content,
       assignee_ids: assigneeIds,
       observer_ids: referenceIds,
-      file_ids: fileIdsForSubmit,
+      file_ids: sortedFileIdsForSubmit,
     };
 
     const cleanSnapshot = {
@@ -363,6 +404,7 @@ const InquiryFormPage = () => {
       fileIds: [] as number[],
     };
 
+    // 편집
     if (isEdit && editTeamId && editInquiryId) {
       putInquiryMutation.mutate(
         { team_id: editTeamId, inquiry_id: editInquiryId, data: payload },
@@ -376,6 +418,7 @@ const InquiryFormPage = () => {
       return;
     }
 
+    // 신규 등록
     if (!teamId) return;
 
     deleteDraftBeforeSubmit(() => {
@@ -415,7 +458,7 @@ const InquiryFormPage = () => {
     content,
     assigneeIds,
     referenceIds,
-    fileIdsForSubmit,
+    sortedFileIdsForSubmit,
     putInquiryMutation,
     postInquiryMutation,
     deleteDraftBeforeSubmit,

--- a/src/pages/inquiryDetail/InquiryDetailPage.tsx
+++ b/src/pages/inquiryDetail/InquiryDetailPage.tsx
@@ -3,6 +3,7 @@ import { useOutletContext, useParams } from "react-router-dom";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import Modal from "@/components/common/Modal";
 import FollowUpSection from "@/components/Followup/FollowupSection";
+import InquiryLeaveModal from "@/components/inquiry/common/InquiryLeaveModal";
 import AnswerSection from "@/components/inquiry/detail/answer/AnswerSection";
 import Header from "@/components/inquiry/detail/Header";
 import InquiryCard from "@/components/inquiry/detail/InquiryCard";
@@ -45,6 +46,7 @@ const InquiryDetailPage = () => {
     setSelectedFileIds,
     isEditMode,
     onToggleNotification,
+    leaveModal,
   } = useInquiryDetail();
 
   const { openAddMemberSidebar } = useOutletContext<{
@@ -181,6 +183,7 @@ const InquiryDetailPage = () => {
           buttons={modalProps.buttons}
         />
       )}
+      <InquiryLeaveModal {...leaveModal} />
     </div>
   );
 };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,0 +1,46 @@
+import { createBrowserRouter } from "react-router-dom";
+
+import AssignedPage from "@/pages/assigned/AssignedPage";
+import HomePage from "@/pages/home/HomePage";
+import InquiryFormPage from "@/pages/inquiry/InquiryFormPage";
+import InquiryDetailPage from "@/pages/inquiryDetail/InquiryDetailPage";
+import LoginPage from "@/pages/login/LoginPage";
+import MyQuestionsPage from "@/pages/myQuestions/MyQuestionsPage";
+import NotFoundPage from "@/pages/notFound/NotFoundPage";
+import ScrapPage from "@/pages/scrap/ScrapPage";
+import SearchResultPage from "@/pages/searchResult/SearchResultPage";
+import TeamBoardPage from "@/pages/teamBoard/TeamBoardPage";
+import UserSpacePage from "@/pages/userSpace/UserSpacePage";
+import Layout from "@/components/layout/Layout";
+import RequireAuth from "@/components/router/RequireAuth";
+
+export const router = createBrowserRouter([
+  { path: "/login", element: <LoginPage /> },
+
+  // 인증 필요한 영역
+  {
+    element: <RequireAuth />,
+    children: [
+      {
+        path: "/",
+        element: <Layout />,
+        children: [
+          { index: true, element: <HomePage /> },
+          { path: "assigned", element: <AssignedPage /> },
+          { path: "team/:team_id", element: <TeamBoardPage /> },
+          { path: "my-questions", element: <MyQuestionsPage /> },
+          { path: "inquiry/form", element: <InquiryFormPage /> },
+          { path: "scrap", element: <ScrapPage /> },
+          { path: "space/:userId", element: <UserSpacePage /> },
+          {
+            path: "teams/:team_id/inquiries/:inquiry_id",
+            element: <InquiryDetailPage />,
+          },
+          { path: "result", element: <SearchResultPage /> },
+        ],
+      },
+    ],
+  },
+
+  { path: "*", element: <NotFoundPage /> },
+]);

--- a/src/utils/leaveModalUtils.ts
+++ b/src/utils/leaveModalUtils.ts
@@ -1,0 +1,26 @@
+import { UploadFile } from "@/types/file/file.type";
+
+export const mapServerFilesToUploadList = (
+  files: Array<{
+    file_id: number;
+    file_key: string;
+    file_name?: string;
+    file_size?: number;
+  }>
+): UploadFile[] =>
+  files.map(f => ({
+    id: f.file_id,
+    file_id: f.file_id,
+    file_name:
+      f.file_name ?? decodeURIComponent(f.file_key.split("/").pop() ?? "파일"),
+    file_size: f.file_size ?? 0,
+    progress: 100,
+    status: "done",
+  }));
+
+// 업로드 전 임시 파일까지 감지하는 시그니처
+export const buildFileSig = (list: UploadFile[]) =>
+  list.map(
+    f =>
+      `${f.file_id ?? `tmp:${f.id ?? "n"}`}:${f.file_name ?? ""}:${f.file_size ?? 0}:${f.status}`
+  );

--- a/src/utils/queryRetryUtils.ts
+++ b/src/utils/queryRetryUtils.ts
@@ -1,0 +1,8 @@
+import { AxiosError } from "axios";
+
+export const is404 = (e: unknown) =>
+  (e as AxiosError)?.response?.status === 404;
+export const retryIf404 = (failureCount: number, error: unknown) =>
+  is404(error) && failureCount < 15;
+export const retryDelay = (attempt: number) =>
+  Math.min(300 * 2 ** attempt, 3000); // 0.3s → 3s


### PR DESCRIPTION
💡 To Reviewers

- 브라우저 이탈 감지를 위해 전체 라우팅 구조를 리팩터링하였습니다.
- 구체적으로, 기존 App.tsx에서 처리하던 라우팅 관련 로직을 router.tsx로 분리하였으며, useBlocker 기반의 가드를 적용하였습니다.
- 실제 제출 등으로 인해 페이지 이동이 필요한 경우에는 이탈 모달이 뜨지 않도록 bypass 로직으로 우회 처리하였습니다.

----

🔥 작업 내용

- useBlocker 훅을 활용하여 브라우저 이탈 시 사용자에게 확인 모달을 띄우는 기능을 구현하였습니다.
- 아래의 경우, 작성 중인 내용이 있을 경우에 이탈 감지 모달이 등장합니다:

  - a. 문의글 기본 작성 시
  - b. 문의글 수정 중, 내용이 변경된 경우
  - c. 문의글 답변 작성 시
  - d. 문의글 답변 수정 중, 내용이 변경된 경우
  - e. 문의글 추가 답변 작성 시
  - f. 문의글 추가 답변 수정 중, 내용이 변경된 경우

---

### 📸 작업 결과 (선택)
<img width="1470" height="798" alt="스크린샷 2025-09-03 오전 6 51 33" src="https://github.com/user-attachments/assets/d288ac5d-49b9-469a-9389-31345b682ba8" />
<img width="1470" height="798" alt="스크린샷 2025-09-03 오전 6 53 31" src="https://github.com/user-attachments/assets/1ad9d144-43f1-4736-9d85-cf1e7cf2a875" />

<img width="1470" height="956" alt="스크린샷 2025-09-03 오전 5 50 23" src="https://github.com/user-attachments/assets/5698216f-bafa-4ad7-a6ca-7c79761e209f" />

---

### 🔗 관련 이슈 (선택)

- #101 
